### PR TITLE
Better error handling on multisig rotation

### DIFF
--- a/ui/src/components/modals/ChangeMultisig.tsx
+++ b/ui/src/components/modals/ChangeMultisig.tsx
@@ -277,6 +277,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
             isSwapSummary
             balanceMin={neededBalance}
             isBalanceError={!hasSignerEnoughFunds}
+            selectedMultisig={selectedMultisig}
           />
         )}
         {(currentStep === 'call1' || currentStep === 'call2') && (
@@ -314,7 +315,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
           )}
           {!isCallStep && (
             <Button
-              disabled={!!errorMessage || !hasProxyEnoughFunds || !hasSignerEnoughFunds}
+              disabled={!!errorMessage || !hasProxyEnoughFunds || (currentStep === "summary" && !hasSignerEnoughFunds)}
               onClick={onClickNext}
             >{
                 currentStep === "selection"

--- a/ui/src/hooks/useSigningCallback.tsx
+++ b/ui/src/hooks/useSigningCallback.tsx
@@ -5,10 +5,11 @@ import { useToasts } from '../contexts/ToastContext'
 interface Args {
   onSubmitting?: () => void
   onSuccess?: () => void
+  onError?: (message?: string) => void
   onFinalized?: () => void
 }
 
-export const useSigningCallback = ({ onSubmitting, onSuccess, onFinalized }: Args) => {
+export const useSigningCallback = ({ onSubmitting, onSuccess, onFinalized, onError }: Args) => {
   const { addToast } = useToasts()
   const { api } = useApi()
 
@@ -42,7 +43,6 @@ export const useSigningCallback = ({ onSubmitting, onSuccess, onFinalized }: Arg
               )
 
               errorInfo = Array.isArray(error.docs) ? error.docs.join('') : error.docs || ''
-
               // stop looping we found an error
               return true
             }
@@ -77,13 +77,14 @@ export const useSigningCallback = ({ onSubmitting, onSuccess, onFinalized }: Arg
 
         if (!!errorInfo && !toastErrorShown) {
           addToast({ title: errorInfo, type: "error" })
+          onError && onError(errorInfo)
           // prevent showing several errors
           toastErrorShown = true
         }
       });
     } else if (status.isFinalized) {
       onFinalized && onFinalized()
-      !errorInfo && addToast({ title: "Tx finalized", type: "success" })
+      // !errorInfo && addToast({ title: "Tx finalized", type: "success" })
       console.log('Finalized block hash', status.asFinalized.toHex());
     }
   }


### PR DESCRIPTION
closes #37 

Here's how you can get the error:
- initiate a multisig rotation, go through both calls, it should work.
- don't approve/reject any proposal and initiate the exact same rotation.
- if you reject the first addProxy proposal, you should be able to re-initiate the same multisig rotation, the first call should work, the second should fail with a nice error message.