### PR TITLE
Show identity and info on hover/touch

### DIFF
--- a/ui/src/components/AccountDisplay.tsx
+++ b/ui/src/components/AccountDisplay.tsx
@@ -1,10 +1,13 @@
 import { Box } from "@mui/material";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { useAccountNames } from "../contexts/AccountNamesContext";
 import { AccountBadge } from "../types";
 import { getDisplayAddress } from "../utils/getDisplayAddress";
 import IdenticonBadge from "./IdenticonBadge";
+import { useApi } from "../contexts/ApiContext";
+import { DeriveAccountInfo, DeriveAccountRegistration } from '@polkadot/api-derive/types';
+import IdentityIcon from "./IdentityIcon";
 
 interface Props {
   address: string;
@@ -16,11 +19,52 @@ interface Props {
 const AccountDisplay = ({ className, address, badge, withName = true }: Props) => {
   const { getNamesWithExtension } = useAccountNames()
   const displayName = useMemo(() => getNamesWithExtension(address), [address, getNamesWithExtension])
+  const [identity, setIdentity] = useState<DeriveAccountRegistration | null>(null);
+  const { api, isApiReady } = useApi()
+  const [mainDisplay, setMainDisplay] = useState<string>('');
+  const [sub, setSub] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    if (!isApiReady) {
+      return;
+    }
+
+    let unsubscribe: () => void;
+
+    api.derive.accounts.info(address, (info: DeriveAccountInfo) => {
+      setIdentity(info.identity);
+
+      if (info.identity.displayParent && info.identity.display) {
+        // when an identity is a sub identity `displayParent` is set
+        // and `display` get the sub identity
+        setMainDisplay(info.identity.displayParent);
+        setSub(info.identity.display);
+      } else {
+        // There should not be a `displayParent` without a `display`
+        // but we can't be too sure.
+        setMainDisplay(info.identity.displayParent || info.identity.display || info.nickname || '');
+      }
+    })
+      .then(unsub => { unsubscribe = unsub; })
+      .catch(e => console.error(e));
+
+    return () => unsubscribe && unsubscribe();
+  }, [address, api, isApiReady]);
 
   return <Box className={className}>
     <IdenticonBadge badge={badge} address={address} />
     <Box className="nameAddressWrapper">
-      {withName && <div className="name">{displayName}</div>}
+      {withName && (
+        <div className="nameWrapper">
+          {!!identity && mainDisplay && <IdentityIcon className="identityBadge" identity={identity} />}
+          {!!sub && <span className='sub'>/{sub}</span>}
+          <span className="name">{displayName || mainDisplay}</span>
+        </div>
+      )}
       <div className="address">{getDisplayAddress(address)}</div>
     </Box>
   </Box>
@@ -43,6 +87,15 @@ export default styled(AccountDisplay)(({ theme }) => `
   .address {
     color: ${theme.custom.text.addressColorLightGray};
     font-size: small;
+  }
+
+  .nameWrapper {
+    display: flex;
+    align-items: center;
+  }
+
+  .identityBadge {
+    margin-right: 0.3rem;
   }
 
   .name {

--- a/ui/src/components/IdentityIcon.tsx
+++ b/ui/src/components/IdentityIcon.tsx
@@ -1,0 +1,64 @@
+import { Tooltip } from '@mui/material';
+import { DeriveAccountRegistration } from '@polkadot/api-derive/types';
+import styled from 'styled-components';
+import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded';
+import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutlineRounded';
+import { useMemo } from 'react';
+
+interface Props {
+  className?: string
+  identity: DeriveAccountRegistration
+}
+
+const StyledPopup = styled.div`
+list-style: none;
+padding: .5rem;
+
+li:not(:last-child) {
+	margin-bottom: 0.3rem;
+}
+.desc {
+	margin-right: 0.3rem;
+}
+.judgments {
+	display: inline list-item;
+}
+`;
+
+const IdentityIcon = ({ className, identity }: Props) => {
+  const judgements = useMemo(() => identity.judgements.filter(([, judgement]): boolean => !judgement.isFeePaid), [identity])
+  const isGood = useMemo(() => judgements.some(([, judgement]): boolean => judgement.isKnownGood || judgement.isReasonable), [judgements])
+  const isBad = useMemo(() => judgements.some(([, judgement]): boolean => judgement.isErroneous || judgement.isLowQuality), [judgements])
+  const displayJudgements = useMemo(() => JSON.stringify(judgements.map(([, jud]) => jud.toString())).replace(/"|\[|\]/g, ""), [judgements])
+
+  const tooltipContent = <StyledPopup>
+    {identity?.legal && <li><span className='desc'>legal:</span>{identity.legal}</li>}
+    {identity?.email && <li><span className='desc'>email:</span>{identity.email}</li>}
+    {identity?.judgements?.length > 0 && <li><span className='desc'>judgements:</span><span className='judgments'>{displayJudgements}</span></li>}
+    {identity?.pgp && <li><span className='desc'>pgp:</span>{identity.pgp}</li>}
+    {identity?.riot && <li><span className='desc'>riot:</span>{identity.riot}</li>}
+    {identity?.twitter && <li><span className='desc'>twitter:</span>{identity.twitter}</li>}
+    {identity?.web && <li><span className='desc'>web:</span>{identity.web}</li>}
+  </StyledPopup>;
+
+  return (
+    <Tooltip className={className} title={tooltipContent}>
+      {isGood
+        ? <CheckCircleOutlineRoundedIcon className="green" sx={{ color: "green" }} />
+        : <RemoveCircleOutlineRoundedIcon className={isBad ? 'brown' : 'grey'} sx={{ color: isBad ? 'brown' : 'grey' }} />
+      }
+    </Tooltip>
+  )
+};
+
+export default styled(IdentityIcon)`
+	display: inline;
+	
+  svg.green {
+		color: green !important;
+	}
+
+	svg.grey {
+		color: gray !important;
+	}
+`;

--- a/ui/src/components/IdentityIcon.tsx
+++ b/ui/src/components/IdentityIcon.tsx
@@ -1,7 +1,7 @@
 import { Tooltip } from '@mui/material';
 import { DeriveAccountRegistration } from '@polkadot/api-derive/types';
 import styled from 'styled-components';
-import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded';
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
 import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutlineRounded';
 import { useMemo } from 'react';
 
@@ -42,23 +42,27 @@ const IdentityIcon = ({ className, identity }: Props) => {
   </StyledPopup>;
 
   return (
-    <Tooltip className={className} title={tooltipContent}>
+    <Tooltip className={className} title={tooltipContent} >
       {isGood
-        ? <CheckCircleOutlineRoundedIcon className="green" sx={{ color: "green" }} />
-        : <RemoveCircleOutlineRoundedIcon className={isBad ? 'brown' : 'grey'} sx={{ color: isBad ? 'brown' : 'grey' }} />
+        ? <CheckCircleRoundedIcon className="green" />
+        : <RemoveCircleOutlineRoundedIcon className={isBad ? 'red' : 'grey'} />
       }
     </Tooltip>
   )
 };
 
-export default styled(IdentityIcon)`
-	display: inline;
-	
-  svg.green {
-		color: green !important;
-	}
+export default styled(IdentityIcon)(({ theme }) => `
+  display: inline;
 
-	svg.grey {
-		color: gray !important;
-	}
-`;
+  &.green {
+    color: ${theme.custom.identity.green};
+  }
+
+  &.grey {
+    color: ${theme.custom.identity.grey};
+  }
+
+  &.red {
+    color: ${theme.custom.identity.brown};
+  }
+`);

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -16,5 +16,10 @@ export const theme = createTheme({
     background: {
       backgroundColorLightGray: '#ebebeb'
     },
+    identity: {
+      green: "green",
+      grey: "grey",
+      red: "firebrick"
+    }
   }
 } as any)


### PR DESCRIPTION
closes #103 
ready to review for a first pass, but still something to do: Use the identity name in the selection dropdown, or anywhere we think it's needed.

@Lykhoyda this is one of the instance where I had to either use either sx, or a styled component, otherwise I don't have access to the DOM node to style it, because it's appended dynamically at the end of the DOM, it's not inside my styled component.

To test, you need to set an identity (e.g you can do this with pjs/apps) https://wiki.polkadot.network/docs/learn-identity

Here's a watch mode on the ChaosDAO where all members have an identity set.
![image](https://user-images.githubusercontent.com/33178835/234426100-e185d794-fa54-469f-82ac-cd8e17d63423.png)

alternatively, if you want to see this too, you need to

- point your local node at Kusama (see the .env.example comments in ./squid)
- connect the UI to it using ?network=local
- add a hacky watch address such as "HqfNL8eE5Efvw5Wcj8d3tjeoCS3BPfshMHWG6rmtYUrgyrU" who's part of the ChaosDAO multisig (see the Readme of ./ui to know how to do this)