### PR TITLE
Prevent indexer crash for new unsupported proxy types

### DIFF
--- a/packages/squid/schema.graphql
+++ b/packages/squid/schema.graphql
@@ -38,6 +38,7 @@ type ProxyAccount @entity {
 }
 
 # from https://github.com/paritytech/polkadot/blob/476d3ddddf7a8f7361edac92228d0200abac0895/runtime/polkadot/src/lib.rs#L918
+# and https://github.com/paritytech/polkadot/blob/476d3ddddf7a8f7361edac92228d0200abac0895/runtime/kusama/src/lib.rs#L934
 enum ProxyType {
   Any
   Governance
@@ -49,4 +50,5 @@ enum ProxyType {
   SudoBalances
   NominationPools
   Society
+  Unkown # this is added in case a new proxy type comes up and isn't supported yet
 }

--- a/packages/squid/src/model/generated/_proxyType.ts
+++ b/packages/squid/src/model/generated/_proxyType.ts
@@ -9,4 +9,5 @@ export enum ProxyType {
     SudoBalances = "SudoBalances",
     NominationPools = "NominationPools",
     Society = "Society",
+    Unkown = "Unkown",
 }

--- a/packages/squid/src/util/getProxyInfoFromArgs.ts
+++ b/packages/squid/src/util/getProxyInfoFromArgs.ts
@@ -8,7 +8,7 @@ export const getProxyInfoFromArgs = (item: EventItem<"Proxy.ProxyAdded" | "Proxy
   const { delegator, delegatee, proxyType, delay } = item.event.args
   const _delegator = encodeAddress(delegator, env.prefix)
   const _delegatee = encodeAddress(delegatee, env.prefix)
-  const _type = getProxyTypeFromRaw(proxyType)
+  const _type = getProxyTypeFromRaw(proxyType.__kind)
   const _delay = Number(delay) || 0
   const _id = getProxyAccountId(_delegatee, _delegator, _type, _delay)
 

--- a/packages/squid/src/util/getProxyTypeFromRaw.ts
+++ b/packages/squid/src/util/getProxyTypeFromRaw.ts
@@ -1,5 +1,8 @@
 import { ProxyType } from "../model"
 
-export const getProxyTypeFromRaw = (proxyType: { [index: string]: any }) => {
-  return (<any>ProxyType)[proxyType.__kind]
+export const getProxyTypeFromRaw = (proxyType: string) => {
+  if (Object.values(ProxyType).some((type: string) => type === proxyType))
+    return <ProxyType>proxyType;
+  else
+    return ProxyType.Unkown
 }

--- a/packages/squid/src/util/getPureProxyInfoFromArgs.ts
+++ b/packages/squid/src/util/getPureProxyInfoFromArgs.ts
@@ -7,9 +7,8 @@ import { getProxyTypeFromRaw } from "./getProxyTypeFromRaw";
 export const getPureProxyInfoFromArgs = (item: EventItem<"Proxy.PureCreated", typeof dataEvent['data']>) => {
 
   const { pure, who, proxyType } = item.event.args
-  // pure proxy creation delay, they have a disambiguationIndex
+  // pure proxy have no creation delay, they have a disambiguationIndex
   const delay = 0
-  // pure proxy creation always have the any type
   const _type = getProxyTypeFromRaw(proxyType.__kind)
   const _who = encodeAddress(who, env.prefix)
   const _pure = encodeAddress(pure, env.prefix)
@@ -19,7 +18,7 @@ export const getPureProxyInfoFromArgs = (item: EventItem<"Proxy.PureCreated", ty
     id,
     who: _who,
     pure: _pure,
-    delay: delay,
+    delay,
     type: _type
   })
 }

--- a/packages/squid/src/util/getPureProxyInfoFromArgs.ts
+++ b/packages/squid/src/util/getPureProxyInfoFromArgs.ts
@@ -2,22 +2,24 @@ import { EventItem } from "@subsquid/substrate-processor/lib/interfaces/dataSele
 import { encodeAddress } from '@polkadot/util-crypto';
 import { getProxyAccountId } from "./getProxyAccountId";
 import { dataEvent, env } from "../processor"
-import { ProxyType } from "../model";
+import { getProxyTypeFromRaw } from "./getProxyTypeFromRaw";
 
 export const getPureProxyInfoFromArgs = (item: EventItem<"Proxy.PureCreated", typeof dataEvent['data']>) => {
 
-  const { pure, who } = item.event.args
+  const { pure, who, proxyType } = item.event.args
+  // pure proxy creation delay, they have a disambiguationIndex
   const delay = 0
-  const type = ProxyType.Any
+  // pure proxy creation always have the any type
+  const _type = getProxyTypeFromRaw(proxyType.__kind)
   const _who = encodeAddress(who, env.prefix)
   const _pure = encodeAddress(pure, env.prefix)
-  const id = getProxyAccountId(_who, _pure, type, delay)
+  const id = getProxyAccountId(_who, _pure, _type, delay)
 
   return ({
     id,
     who: _who,
     pure: _pure,
-    delay,
-    type
+    delay: delay,
+    type: _type
   })
 }


### PR DESCRIPTION
any proxy type that is not supported will be displayed as "Unknown" now, instead of crashing the indexer