### PR TITLE
Refresh account list even if no account

### DIFF
--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -119,6 +119,8 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
       res.push(...proxyArray)
 
       setMultisigList(res)
+    } else if (!!data?.accounts && data.accounts.length === 0) {
+      setMultisigList([])
     }
   }, [])
 

--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -47,6 +47,11 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
   const selectedHasProxy = useMemo(() => !!selectedMultiProxy?.proxy, [selectedMultiProxy])
 
   const refreshAccounList = useCallback((data: MultisigsByAccountsSubscription | null) => {
+    // we do have an answer, but there is no multiproxy
+    if (!!data?.accounts && data.accounts.length === 0) {
+      setMultisigList([])
+    }
+
     if (!!data?.accounts && data.accounts.length > 0) {
       // map of the pure proxy addresses and the multisigs associated
       const pureProxyMap = new Map<string, Omit<MultiProxy, 'proxy'>>()
@@ -119,10 +124,6 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
       res.push(...proxyArray)
 
       setMultisigList(res)
-
-      // we do have an answer, but there is no multiproxy
-    } else if (!!data?.accounts && data.accounts.length === 0) {
-      setMultisigList([])
     }
   }, [])
 

--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -119,6 +119,8 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
       res.push(...proxyArray)
 
       setMultisigList(res)
+
+      // we do have an answer, but there is no multiproxy
     } else if (!!data?.accounts && data.accounts.length === 0) {
       setMultisigList([])
     }


### PR DESCRIPTION
hot fix for live issue.
The UI shows accounts from the last network on network change, if the new network doesn't have any account.