### PR TITLE
Unify cross chain name storage

### DIFF
--- a/packages/ui/src/components/IdentityIcon.tsx
+++ b/packages/ui/src/components/IdentityIcon.tsx
@@ -49,6 +49,12 @@ const IdentityIcon = ({ className, identity }: Props) => {
 
   const tooltipContent = (
     <StyledPopup>
+      {identity?.display && (
+        <li>
+          <span className="desc">display:</span>
+          {identity.display}
+        </li>
+      )}
       {identity?.legal && (
         <li>
           <span className="desc">legal:</span>

--- a/packages/ui/src/components/MultiProxySelection.tsx
+++ b/packages/ui/src/components/MultiProxySelection.tsx
@@ -2,7 +2,7 @@ import { Autocomplete, Box, InputAdornment, TextField } from '@mui/material'
 import React, { useCallback, useMemo, useRef } from 'react'
 import { styled } from '@mui/material/styles'
 import { createFilterOptions } from '@mui/material/Autocomplete'
-import { useMultiProxy } from '../contexts/MultiProxyContext'
+import { MultiProxy, useMultiProxy } from '../contexts/MultiProxyContext'
 import AccountDisplay from './AccountDisplay'
 import IdenticonBadge from './IdenticonBadge'
 import { useAccountNames } from '../contexts/AccountNamesContext'
@@ -11,6 +11,9 @@ import { AccountBadge } from '../types'
 interface Props {
   className?: string
 }
+
+const getDisplayAddress = (option?: MultiProxy) =>
+  option?.proxy ? option?.proxy : option?.multisigs[0].address
 
 const MultiProxySelection = ({ className }: Props) => {
   const { multiProxyList, selectedMultiProxy, selectMultiProxy } = useMultiProxy()
@@ -24,15 +27,18 @@ const MultiProxySelection = ({ className }: Props) => {
   const { accountNames } = useAccountNames()
   const filterOptions = createFilterOptions({
     ignoreCase: true,
-    stringify: (option: typeof selectedMultiProxy) =>
-      `${option?.proxy}${option?.multisigs[0].address}` || ''
+    stringify: (option: typeof selectedMultiProxy) => {
+      const displayAddress = getDisplayAddress(option)
+      return (
+        `${option?.proxy}${option?.multisigs[0].address}${accountNames[displayAddress || '']}` || ''
+      )
+    }
   })
 
   const getOptionLabel = useCallback(
     (option: typeof selectedMultiProxy) => {
       // We only support one multisigs if they have no proxy
       const addressToSearch = option?.proxy || option?.multisigs[0].address
-
       const name = !!addressToSearch && accountNames[addressToSearch]
       return name || (addressToSearch as string)
     },
@@ -65,8 +71,7 @@ const MultiProxySelection = ({ className }: Props) => {
       filterOptions={filterOptions}
       options={multiProxyList}
       renderOption={(props, option) => {
-        const isProxy = !!option?.proxy
-        const displayAddress = isProxy ? option?.proxy : option?.multisigs[0].address
+        const displayAddress = getDisplayAddress(option)
 
         return (
           <Box

--- a/packages/ui/src/components/MultisigCompactDisplay.tsx
+++ b/packages/ui/src/components/MultisigCompactDisplay.tsx
@@ -55,8 +55,8 @@ const MultisigCompactDisplay = ({ className, address, expanded = false }: Props)
 
   return (
     <Box className={className}>
-      <AccountDisplay
-        className={`${signatories.length > 0 ? 'multisigAccount' : ''}`}
+      <AccountDisplayStyled
+        isMultisig={signatories.length > 0}
         address={address}
         badge={badge}
       />
@@ -91,14 +91,14 @@ const MultisigCompactDisplay = ({ className, address, expanded = false }: Props)
 }
 
 export default styled(MultisigCompactDisplay)`
-  margin-top: 0.5rem;
-
-  .multisigAccount {
-    margin-top: 0.5rem;
-    margin-left: 0.5rem;
-  }
-
   .signatoryList {
     list-style-type: none;
   }
 `
+
+const AccountDisplayStyled = styled(AccountDisplay)<{ isMultisig: boolean }>(
+  ({ isMultisig }) => `
+      ${isMultisig && 'margin-top: 0.5rem'};
+      ${isMultisig && 'margin-left: 0.5rem'};
+`
+)

--- a/packages/ui/src/contexts/WatchedAddressesContext.tsx
+++ b/packages/ui/src/contexts/WatchedAddressesContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useApi } from './ApiContext'
 import { reEncodeInjectedAccounts } from '../utils/reEncodeInjectedAccounts'
+import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
+import { u8aToHex } from '@polkadot/util'
 
 const LOCALSTORAGE_WATCHED_ACCOUNTS_KEY = 'multix.watchedAccount'
 
@@ -24,7 +26,7 @@ const WatchedAddressesContextProvider = ({ children }: WatchedAddressesProps) =>
   // update the current account list with the right network prefix
   // this will run for every network change
   useEffect(() => {
-    if (chainInfo?.ss58Format) {
+    if (chainInfo) {
       setWatchedAddresses((prev) => {
         return reEncodeInjectedAccounts(prev, chainInfo.ss58Format) as string[]
       })
@@ -44,14 +46,21 @@ const WatchedAddressesContextProvider = ({ children }: WatchedAddressesProps) =>
   )
 
   const loadWatchedAccounts = useCallback(() => {
+    if (!chainInfo) {
+      return
+    }
+
     const localStorageWatchedAccount = localStorage.getItem(LOCALSTORAGE_WATCHED_ACCOUNTS_KEY)
     const watchedArray: string[] = localStorageWatchedAccount
       ? JSON.parse(localStorageWatchedAccount)
       : []
 
-    setWatchedAddresses(watchedArray)
+    const encodedAddresses = watchedArray.map((pubKey) =>
+      encodeAddress(pubKey, chainInfo.ss58Format)
+    )
+    setWatchedAddresses(encodedAddresses)
     setIsInitialized(true)
-  }, [])
+  }, [chainInfo])
 
   useEffect(() => {
     !isInitialized && loadWatchedAccounts()
@@ -61,7 +70,8 @@ const WatchedAddressesContextProvider = ({ children }: WatchedAddressesProps) =>
   useEffect(() => {
     if (!isInitialized) return
 
-    localStorage.setItem(LOCALSTORAGE_WATCHED_ACCOUNTS_KEY, JSON.stringify(watchedAddresses))
+    const pubKeyArray = watchedAddresses.map((address) => u8aToHex(decodeAddress(address)))
+    localStorage.setItem(LOCALSTORAGE_WATCHED_ACCOUNTS_KEY, JSON.stringify(pubKeyArray))
   }, [isInitialized, watchedAddresses])
 
   return (

--- a/packages/ui/src/pages/Creation/Summary.tsx
+++ b/packages/ui/src/pages/Creation/Summary.tsx
@@ -55,10 +55,9 @@ const Summary = ({
       {isSwapSummary && proxyAddress ? (
         <>
           <h3>You are about to change the Multisig controlling:</h3>
-          <AccountDisplay
+          <AccoutDisplayProxyStyled
             address={proxyAddress}
             badge={AccountBadge.PURE}
-            className="proxyName"
           />
         </>
       ) : (
@@ -124,6 +123,10 @@ const Summary = ({
   )
 }
 
+const AccoutDisplayProxyStyled = styled(AccountDisplay)`
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+`
 export default styled(Summary)`
   width: 100%;
 
@@ -152,11 +155,6 @@ export default styled(Summary)`
   .signerSelection {
     margin-top: 1rem;
     margin-bottom: 3rem;
-  }
-
-  .proxyName {
-    padding-left: 1.5rem;
-    margin-bottom: 1.5rem;
   }
 
   .name {

--- a/packages/ui/src/pages/Home.tsx
+++ b/packages/ui/src/pages/Home.tsx
@@ -361,10 +361,6 @@ export default styled(Home)(
     align-items: center;
   }
 
-  .identicon {
-    margin-right: .5rem;
-  }
-
   .signatoriesWrapper {
     & > h2 {
       margin-bottom: 0;

--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -1,4 +1,3 @@
-import { styled } from '@mui/material/styles'
 import { Box } from '@mui/material'
 import WatchedAccounts from '../components/WatchedAccounts'
 
@@ -15,8 +14,4 @@ const Settings = ({ className }: Props) => {
   )
 }
 
-export default styled(Settings)`
-  .identicon {
-    margin-right: 0.5rem;
-  }
-`
+export default Settings

--- a/packages/ui/src/utils/namesUtil.ts
+++ b/packages/ui/src/utils/namesUtil.ts
@@ -1,0 +1,23 @@
+import { encodeAddress, decodeAddress } from '@polkadot/util-crypto'
+import { u8aToHex } from '@polkadot/util'
+import { AccountNames } from '../contexts/AccountNamesContext'
+
+export const encodeNames = (accounts: AccountNames, ss58Format: number) => {
+  const res = {} as AccountNames
+
+  Object.entries(accounts).forEach(([pubkey, name]) => {
+    const address = encodeAddress(pubkey, ss58Format)
+    res[address] = name
+  })
+  return res
+}
+
+export const decodeNames = (accounts: AccountNames) => {
+  const res = {} as AccountNames
+
+  Object.entries(accounts).forEach(([address, name]) => {
+    const pubkey = u8aToHex(decodeAddress(address))
+    res[pubkey] = name
+  })
+  return res
+}


### PR DESCRIPTION
closes #174 #173 

This is quite a big one touching many things
- Account display across the board (including things like multisig display in call information when rotating signatories)
- We now show the local  name before the on-chain identity name. This one is now visible in the drop-down
- Storing pub key in localStorage now instead of address both for names and watched accounts
- Show the account address with the current network's prefix whatever the user typed in