### PR TITLE
Fix console errors

### DIFF
--- a/packages/ui/src/components/MultiProxySelection.tsx
+++ b/packages/ui/src/components/MultiProxySelection.tsx
@@ -2,7 +2,7 @@ import { Autocomplete, Box, InputAdornment, TextField } from '@mui/material'
 import React, { useCallback, useMemo, useRef } from 'react'
 import { styled } from '@mui/material/styles'
 import { createFilterOptions } from '@mui/material/Autocomplete'
-import { useMultiProxy } from '../contexts/MultiProxyContext'
+import { MultiProxy, useMultiProxy } from '../contexts/MultiProxyContext'
 import AccountDisplay from './AccountDisplay'
 import IdenticonBadge from './IdenticonBadge'
 import { useAccountNames } from '../contexts/AccountNamesContext'
@@ -10,6 +10,15 @@ import { AccountBadge } from '../types'
 
 interface Props {
   className?: string
+}
+
+const isOptionEqualToValue = (option: MultiProxy | undefined, value: MultiProxy | undefined) => {
+  if (!option || !value) return false
+
+  if (!!option.proxy || !!value.proxy) {
+    return option.proxy === value.proxy
+  }
+  return option.multisigs[0].address === value.multisigs[0].address
 }
 
 const MultiProxySelection = ({ className }: Props) => {
@@ -61,6 +70,7 @@ const MultiProxySelection = ({ className }: Props) => {
   return (
     <Autocomplete
       className={className}
+      isOptionEqualToValue={isOptionEqualToValue}
       disableClearable
       filterOptions={filterOptions}
       options={multiProxyList}

--- a/packages/ui/src/components/SignerSelection.tsx
+++ b/packages/ui/src/components/SignerSelection.tsx
@@ -1,5 +1,5 @@
 import { Autocomplete, Box, InputAdornment, TextField } from '@mui/material'
-import React, { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { styled } from '@mui/material/styles'
 import { createFilterOptions } from '@mui/material/Autocomplete'
 import { useAccounts } from '../contexts/AccountsContext'
@@ -17,6 +17,15 @@ const getOptionLabel = (option: InjectedAccountWithMeta | undefined) => {
   if (!option) return ''
 
   return option.meta.name || ''
+}
+
+const isOptionEqualToValue = (
+  option: InjectedAccountWithMeta | undefined,
+  value: InjectedAccountWithMeta | undefined
+) => {
+  if (!option || !value) return false
+
+  return option.address === value.address
 }
 
 const SignerSelection = ({ className, possibleSigners, onChange }: Props) => {
@@ -54,6 +63,7 @@ const SignerSelection = ({ className, possibleSigners, onChange }: Props) => {
 
   return (
     <Autocomplete
+      isOptionEqualToValue={isOptionEqualToValue}
       disableClearable
       className={className}
       options={signersList}

--- a/packages/ui/src/hooks/useMultisigCallsSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigCallsSubscription.tsx
@@ -16,8 +16,8 @@ interface Args {
 export const useMultisigCallSubscription = ({ onUpdate, multisigs }: Args) => {
   const { selectedNetworkInfo, selectedNetwork } = useNetwork()
   const client = useMemo(
-    () => createClient({ url: selectedNetworkInfo?.wsGraphqlUrl || '' }),
-    [selectedNetworkInfo?.wsGraphqlUrl]
+    () => selectedNetworkInfo && createClient({ url: selectedNetworkInfo.wsGraphqlUrl }),
+    [selectedNetworkInfo]
   )
 
   /**
@@ -40,15 +40,18 @@ export const useMultisigCallSubscription = ({ onUpdate, multisigs }: Args) => {
 
   const { isError, error } = useSubscription(
     [`KeyMultisigCallsByMultisigId-${multisigs}-${selectedNetwork}`],
-    () =>
-      fromWsClientSubscription<{
+    () => {
+      if (!client) return new Observable<null>()
+
+      return fromWsClientSubscription<{
         multisigCalls: MultisigCallsByMultisigIdSubscription
       }>(client, {
         query: MultisigCallsByMultisigIdDocument,
         variables: {
           multisigs
         }
-      }),
+      })
+    },
     {
       onData: () => {
         onUpdate()

--- a/packages/ui/src/hooks/useMultisigsByAccountSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigsByAccountSubscription.tsx
@@ -18,8 +18,8 @@ export const useMultisigsByAccountSubscription = ({
 }: Args) => {
   const { selectedNetworkInfo, selectedNetwork } = useNetwork()
   const client = useMemo(
-    () => createClient({ url: selectedNetworkInfo?.wsGraphqlUrl || '' }),
-    [selectedNetworkInfo?.wsGraphqlUrl]
+    () => selectedNetworkInfo && createClient({ url: selectedNetworkInfo.wsGraphqlUrl }),
+    [selectedNetworkInfo]
   )
 
   /**
@@ -47,6 +47,8 @@ export const useMultisigsByAccountSubscription = ({
   const { isError, error, data, isLoading } = useSubscription(
     [`KeyMultisigsByAccount-${accounts}-${watchedAccounts}-${selectedNetwork}`],
     () => {
+      if (!client) return new Observable<null>()
+
       return fromWsClientSubscription<{
         accounts: MultisigsByAccountsSubscription['accounts']
       }>(client, {
@@ -59,12 +61,11 @@ export const useMultisigsByAccountSubscription = ({
     },
     {
       onData(data) {
-        onUpdate(data)
+        !!data && onUpdate(data)
       },
       onError(error) {
         console.error('KeyMultisigsByAccount subscription error', error)
       }
-      // options
     }
   )
 

--- a/packages/ui/src/pages/Creation/index.tsx
+++ b/packages/ui/src/pages/Creation/index.tsx
@@ -333,7 +333,7 @@ export default styled(MultisigCreation)(
     width: 100%;
   }
 
-  .buttonContainer button:first-child {
+  .buttonContainer button:first-of-type {
     margin-right: 2rem;
   }
 


### PR DESCRIPTION
closes #169 

Also fixes
> The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type". 

and
> MUI: The value provided to Autocomplete is invalid.
None of the options match with `""`.
You can use the `isOptionEqualToValue` prop to customize the equality test.