### PR TITLE
Fix chainInfo for Polkadot

### DIFF
--- a/packages/ui/src/components/AccountDisplay.tsx
+++ b/packages/ui/src/components/AccountDisplay.tsx
@@ -36,7 +36,7 @@ const AccountDisplay = ({
   const [encodedAddress, setEncodedAddress] = useState('')
 
   useEffect(() => {
-    if (!chainInfo?.ss58Format) {
+    if (!chainInfo) {
       return
     }
 

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -87,7 +87,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
       return
     }
 
-    if (!chainInfo?.ss58Format) {
+    if (!chainInfo) {
       // console.error('no ss58Format from chainInfo')
       return
     }
@@ -107,7 +107,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
     )
     const newMultiAddress = encodeAddress(
       createKeyMulti(newSignatories, newThreshold),
-      chainInfo?.ss58Format
+      chainInfo.ss58Format
     )
     const addProxyTx = api.tx.proxy.addProxy(newMultiAddress, 'Any', 0)
     const proxyTx = api.tx.proxy.proxy(selectedMultiProxy?.proxy, null, addProxyTx)
@@ -136,7 +136,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
       return
     }
 
-    if (!chainInfo?.ss58Format) {
+    if (!chainInfo) {
       // console.error('no ss58Format from chainInfo')
       return
     }

--- a/packages/ui/src/contexts/AccountNamesContext.tsx
+++ b/packages/ui/src/contexts/AccountNamesContext.tsx
@@ -42,7 +42,7 @@ const AccountNamesContextProvider = ({ children }: AccountNamesContextProps) => 
   const loadNames = useCallback(() => {
     const namesHexString = localStorage.getItem(LOCALSTORAGE_ACCOUNT_KEY)
 
-    if (!chainInfo?.ss58Format) {
+    if (!chainInfo) {
       return
     }
 

--- a/packages/ui/src/contexts/AccountsContext.tsx
+++ b/packages/ui/src/contexts/AccountsContext.tsx
@@ -43,7 +43,7 @@ const AccountContextProvider = ({ children }: AccountContextProps) => {
   // update the current account list with the right network prefix
   // this will run for every network change
   useEffect(() => {
-    if (chainInfo?.ss58Format) {
+    if (chainInfo) {
       setOwnAccountList((prev) => {
         return reEncodeInjectedAccounts(prev, chainInfo.ss58Format) as InjectedAccountWithMeta[]
       })

--- a/packages/ui/src/pages/Creation/index.tsx
+++ b/packages/ui/src/pages/Creation/index.tsx
@@ -48,7 +48,7 @@ const MultisigCreation = ({ className }: Props) => {
       return
     }
 
-    if (!chainInfo?.ss58Format) {
+    if (!chainInfo) {
       return
     }
 


### PR DESCRIPTION
Polkadot has prefix 0. After https://github.com/ChainSafe/Multix/pull/177 was merged with re-encoding, things broke because of the checks for `chainInfo?.ss58Format`