### PR TITLE
Hotfix encoding evm crash

### DIFF
--- a/packages/ui/src/components/AccountDisplay.tsx
+++ b/packages/ui/src/components/AccountDisplay.tsx
@@ -40,7 +40,11 @@ const AccountDisplay = ({
       return
     }
 
-    setEncodedAddress(encodeAddress(address, chainInfo.ss58Format))
+    try {
+      setEncodedAddress(encodeAddress(address, chainInfo.ss58Format))
+    } catch (e) {
+      console.error(`Error encoding the address ${address}, skipping`, e)
+    }
   }, [address, chainInfo, encodedAddress])
 
   useEffect(() => {

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -105,10 +105,15 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
     const otherOldSignatories = sortAddresses(
       selectedMultisig.signatories.filter((sig) => sig !== selectedAccount.address)
     )
-    const newMultiAddress = encodeAddress(
-      createKeyMulti(newSignatories, newThreshold),
-      chainInfo.ss58Format
-    )
+
+    const multisigPubKey = createKeyMulti(newSignatories, newThreshold)
+    let newMultiAddress: string | undefined
+    try {
+      newMultiAddress = encodeAddress(multisigPubKey, chainInfo.ss58Format)
+    } catch (e) {
+      console.error(`Error encoding the address ${multisigPubKey}, skipping`, e)
+    }
+
     const addProxyTx = api.tx.proxy.addProxy(newMultiAddress, 'Any', 0)
     const proxyTx = api.tx.proxy.proxy(selectedMultiProxy?.proxy, null, addProxyTx)
     // call with the old multisig

--- a/packages/ui/src/contexts/AccountsContext.tsx
+++ b/packages/ui/src/contexts/AccountsContext.tsx
@@ -4,7 +4,7 @@ import { InjectedAccountWithMeta, InjectedExtension } from '@polkadot/extension-
 import { DAPP_NAME } from '../constants'
 import { Signer } from '@polkadot/api/types'
 import { useApi } from './ApiContext'
-import { reEncodeInjectedAccounts } from '../utils/reEncodeInjectedAccounts'
+import { encodeAccounts } from '../utils/encodeAccounts'
 
 const LOCALSTORAGE_SELECTED_ACCOUNT_KEY = 'multix.selectedAccount'
 const LOCALSTORAGE_ALLOWED_CONNECTION_KEY = 'multix.canConnectToExtension'
@@ -45,7 +45,7 @@ const AccountContextProvider = ({ children }: AccountContextProps) => {
   useEffect(() => {
     if (chainInfo) {
       setOwnAccountList((prev) => {
-        return reEncodeInjectedAccounts(prev, chainInfo.ss58Format) as InjectedAccountWithMeta[]
+        return encodeAccounts(prev, chainInfo.ss58Format) as InjectedAccountWithMeta[]
       })
     }
   }, [chainInfo])

--- a/packages/ui/src/contexts/WatchedAddressesContext.tsx
+++ b/packages/ui/src/contexts/WatchedAddressesContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useApi } from './ApiContext'
-import { reEncodeInjectedAccounts } from '../utils/reEncodeInjectedAccounts'
+import { encodeAccounts } from '../utils/encodeAccounts'
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto'
 import { u8aToHex } from '@polkadot/util'
 
@@ -28,7 +28,7 @@ const WatchedAddressesContextProvider = ({ children }: WatchedAddressesProps) =>
   useEffect(() => {
     if (chainInfo) {
       setWatchedAddresses((prev) => {
-        return reEncodeInjectedAccounts(prev, chainInfo.ss58Format) as string[]
+        return encodeAccounts(prev, chainInfo.ss58Format) as string[]
       })
     }
   }, [chainInfo])
@@ -63,10 +63,7 @@ const WatchedAddressesContextProvider = ({ children }: WatchedAddressesProps) =>
       ? JSON.parse(localStorageWatchedAccount)
       : []
 
-    const encodedAddresses = reEncodeInjectedAccounts(
-      watchedArray,
-      chainInfo.ss58Format
-    ) as string[]
+    const encodedAddresses = encodeAccounts(watchedArray, chainInfo.ss58Format) as string[]
 
     setWatchedAddresses(encodedAddresses)
     setIsInitialized(true)

--- a/packages/ui/src/pages/Creation/index.tsx
+++ b/packages/ui/src/pages/Creation/index.tsx
@@ -52,7 +52,14 @@ const MultisigCreation = ({ className }: Props) => {
       return
     }
 
-    return encodeAddress(createKeyMulti(signatories, threshold), chainInfo.ss58Format)
+    const multiPubKey = createKeyMulti(signatories, threshold)
+    let res: string | undefined
+    try {
+      res = encodeAddress(multiPubKey, chainInfo.ss58Format)
+    } catch (e) {
+      console.error(`Error encoding the address ${multiPubKey}, skipping`, e)
+    }
+    return res
   }, [chainInfo, signatories, threshold])
   const batchCall = useMemo(() => {
     if (!isApiReady || !api) {

--- a/packages/ui/src/utils/encodeAccounts.ts
+++ b/packages/ui/src/utils/encodeAccounts.ts
@@ -1,7 +1,7 @@
 import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types'
 import { encodeAddress } from '@polkadot/util-crypto'
 
-export const reEncodeInjectedAccounts = (
+export const encodeAccounts = (
   accounts: InjectedAccountWithMeta[] | string[],
   ss58Format: number
 ) => {

--- a/packages/ui/src/utils/namesUtil.ts
+++ b/packages/ui/src/utils/namesUtil.ts
@@ -6,8 +6,14 @@ export const encodeNames = (accounts: AccountNames, ss58Format: number) => {
   const res = {} as AccountNames
 
   Object.entries(accounts).forEach(([pubkey, name]) => {
-    const address = encodeAddress(pubkey, ss58Format)
-    res[address] = name
+    let address: string | undefined
+
+    try {
+      address = encodeAddress(pubkey, ss58Format)
+      res[address] = name
+    } catch (e) {
+      console.error(`Error encoding the address ${address}, skipping`, e)
+    }
   })
   return res
 }
@@ -16,8 +22,13 @@ export const decodeNames = (accounts: AccountNames) => {
   const res = {} as AccountNames
 
   Object.entries(accounts).forEach(([address, name]) => {
-    const pubkey = u8aToHex(decodeAddress(address))
-    res[pubkey] = name
+    let pubkey: string | undefined
+    try {
+      pubkey = u8aToHex(decodeAddress(address))
+      res[pubkey] = name
+    } catch (e) {
+      console.error(`Error decoding the address ${address}, skipping`, e)
+    }
   })
   return res
 }

--- a/packages/ui/src/utils/reEncodeInjectedAccounts.ts
+++ b/packages/ui/src/utils/reEncodeInjectedAccounts.ts
@@ -5,12 +5,27 @@ export const reEncodeInjectedAccounts = (
   accounts: InjectedAccountWithMeta[] | string[],
   ss58Format: number
 ) => {
-  return accounts.map((account) =>
-    typeof account === 'string'
-      ? encodeAddress(account, ss58Format)
-      : ({
-          ...account,
-          address: encodeAddress(account.address, ss58Format)
-        } as InjectedAccountWithMeta)
-  )
+  return accounts
+    .map((account) => {
+      let encodedAddress: string | undefined
+      const addressToEncode = typeof account === 'string' ? account : account.address
+
+      try {
+        encodedAddress = encodeAddress(addressToEncode, ss58Format)
+      } catch (e) {
+        console.error(`Error encoding the address ${addressToEncode}, skipping`, e)
+      }
+
+      if (typeof account === 'string') {
+        return encodedAddress
+      }
+
+      return encodedAddress
+        ? ({
+            ...account,
+            address: encodedAddress
+          } as InjectedAccountWithMeta)
+        : null
+    })
+    .filter((acc) => !!acc) as (string | InjectedAccountWithMeta)[]
 }


### PR DESCRIPTION
If using an evm address, the encoding is throwing. We needed to handle this case in a catch accordingly.

this happens when on using Talisman, you have an EVM account and tick the box "show evm account".

![image](https://github.com/ChainSafe/Multix/assets/33178835/11aed16f-7cfb-49c7-9eb1-74c0392dce5e)
