### PR TITLE
Never hide errors

### DIFF
--- a/packages/ui/src/components/Toasts/ToastBar.tsx
+++ b/packages/ui/src/components/Toasts/ToastBar.tsx
@@ -34,7 +34,7 @@ const ToastBar = ({ toast, className }: Props) => {
       className={className}
       open={true}
       anchorOrigin={{ vertical: VERTICAL_POSITION, horizontal: HORIZONTAL_POSITION }}
-      autoHideDuration={toast.type === 'error' ? 0 : duration || DEFAULT_AUTO_HIDE_DURATION}
+      autoHideDuration={toast.type === 'error' ? null : duration || DEFAULT_AUTO_HIDE_DURATION}
       onClose={handleClose}
       key={id}
       action={

--- a/packages/ui/src/components/Toasts/ToastBar.tsx
+++ b/packages/ui/src/components/Toasts/ToastBar.tsx
@@ -34,7 +34,7 @@ const ToastBar = ({ toast, className }: Props) => {
       className={className}
       open={true}
       anchorOrigin={{ vertical: VERTICAL_POSITION, horizontal: HORIZONTAL_POSITION }}
-      autoHideDuration={duration || DEFAULT_AUTO_HIDE_DURATION}
+      autoHideDuration={toast.type === 'error' ? 0 : duration || DEFAULT_AUTO_HIDE_DURATION}
       onClose={handleClose}
       key={id}
       action={


### PR DESCRIPTION
An issue was reported to me by @freddyli7 but the error must have disappeared before he came back to Multix. As a result, it was hard to know, what went wrong unless you go check subscan (and because it's a multisig extrinsic, this isn't easy either).

I had removed this behavior because I thought it was annoying to users, it turns out that since it's rather an exception, bothering users and asking them to manually close the error isn't that annoying either and may actually help them.