### PR TITLE
Fix toasts not displayed at the bottom

### DIFF
--- a/packages/ui/src/components/Toasts/Snackbar.tsx
+++ b/packages/ui/src/components/Toasts/Snackbar.tsx
@@ -26,7 +26,7 @@ const Snackbar = ({ className }: Props) => {
 }
 
 export default styled(Snackbar)`
-  position: absolute;
+  position: fixed;
   bottom: 1rem;
   left: 1rem;
 `


### PR DESCRIPTION
This issue happens when you have many proposals in the queue, and not a large (high) screen.
Then the toasts show up in the middle of the screen instead of the bottom.

![image](https://github.com/ChainSafe/Multix/assets/33178835/e740dad4-1d68-4fad-b766-cf45c01ad46f)
