### PR TITLE
fix nit on depositBase check

### DIFF
--- a/packages/ui/src/hooks/useMultisigProposalNeededFunds.tsx
+++ b/packages/ui/src/hooks/useMultisigProposalNeededFunds.tsx
@@ -23,7 +23,7 @@ export const useMultisigProposalNeededFunds = ({ threshold, signatories, call }:
 
     if (!call) return
 
-    if (!api.consts.multisig.depositFactor || api.consts.multisig.depositBase) return
+    if (!api.consts.multisig.depositFactor || !api.consts.multisig.depositBase) return
 
     try {
       const genericCall = api.createType('Call', call)


### PR DESCRIPTION
The impact should have been null since the `depositFactor` and `depositBase` should be available at the same time.
Still not intended.