### PR TITLE
Better onboading experience

### DIFF
--- a/packages/ui/src/components/NewMulisigAlert.tsx
+++ b/packages/ui/src/components/NewMulisigAlert.tsx
@@ -32,6 +32,7 @@ const NewMulisigAlert = ({ className = '', onClose }: Props) => {
 
 export default styled(NewMulisigAlert)`
   width: 100%;
+  margin-top: 1rem;
 
   .infoText {
     flex: 1;
@@ -41,5 +42,9 @@ export default styled(NewMulisigAlert)`
     display: flex;
     align-items: center;
     width: 100%;
+  }
+
+  .MuiAlert-icon {
+    align-items: center;
   }
 `

--- a/packages/ui/src/pages/Creation/index.tsx
+++ b/packages/ui/src/pages/Creation/index.tsx
@@ -1,5 +1,5 @@
-import { Alert, Box, Grid, Step, StepLabel, Stepper } from '@mui/material'
-import { Button } from '../../components/library'
+import { Alert, Box, CircularProgress, Grid, Step, StepLabel, Stepper } from '@mui/material'
+import { Button, ButtonWithIcon } from '../../components/library'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { styled } from '@mui/material/styles'
 import { useApi } from '../../contexts/ApiContext'
@@ -38,6 +38,7 @@ const MultisigCreation = ({ className }: Props) => {
   const { addToast } = useToasts()
   const [name, setName] = useState('')
   const { addName } = useAccountNames()
+  const [isSubmitted, setIsSubmitted] = useState(false)
   const ownAccountPartOfSignatories = useMemo(
     () => signatories.some((sig) => ownAddressList.includes(sig)),
     [ownAddressList, signatories]
@@ -164,10 +165,13 @@ const MultisigCreation = ({ className }: Props) => {
     }
 
     multiAddress && addName(name, multiAddress)
+    setIsSubmitted(true)
 
     batchCall
       .signAndSend(selectedAccount.address, { signer: selectedSigner }, signCallBack)
       .catch((error: Error) => {
+        setIsSubmitted(false)
+
         addToast({
           title: error.message,
           type: 'error',
@@ -317,18 +321,40 @@ const MultisigCreation = ({ className }: Props) => {
           >
             Back
           </Button>
-          <Button
-            variant="primary"
-            disabled={!canGoNext}
-            onClick={goNext}
-          >
-            {isLastStep ? 'Create' : 'Next'}
-          </Button>
+          {!isSubmitted && (
+            <Button
+              variant="primary"
+              disabled={!canGoNext}
+              onClick={goNext}
+            >
+              {isLastStep ? 'Create' : 'Next'}
+            </Button>
+          )}
+          {isSubmitted && (
+            <ButtonWithIcon
+              variant="primary"
+              aria-label="send"
+              disabled={true}
+            >
+              <LoaderStyled />
+              Creating...
+            </ButtonWithIcon>
+          )}
         </div>
       </Grid>
     </Grid>
   )
 }
+
+const LoaderStyled = styled(CircularProgress)`
+  width: 1.5rem !important;
+  height: 1.5rem !important;
+  margin-right: 4px;
+
+  & > svg {
+    margin: 0;
+  }
+`
 
 export default styled(MultisigCreation)(
   ({ theme }) => `
@@ -356,6 +382,7 @@ export default styled(MultisigCreation)(
   }
 
   .buttonWrapper {
+    display: flex;
     margin-top: 1rem;
     align-self: center;
   }

--- a/packages/ui/src/pages/Home.tsx
+++ b/packages/ui/src/pages/Home.tsx
@@ -163,19 +163,19 @@ const Home = ({ className }: Props) => {
     )
   }
 
-  if (isExtensionError)
+  if (isExtensionError && !watchedAddresses)
     return (
       <CenterStyled>
-        <h1>
+        <h3>
           No account found. Please connect at least one in a wallet extension. More info at{' '}
           <Link
             href="https://wiki.polkadot.network/docs/wallets"
-            target={'_blank'}
+            target="_blank"
             rel="noreferrer"
           >
             wiki.polkadot.network
           </Link>
-        </h1>
+        </h3>
       </CenterStyled>
     )
 
@@ -223,7 +223,7 @@ const Home = ({ className }: Props) => {
             <SuccessCreation />
           ) : (
             <WrapperConnectButtonStyled>
-              No multisig found for your accounts.{' '}
+              No multisig found for your accounts or watched accounts.{' '}
               {isAllowedToConnectToExtension ? (
                 <Button onClick={() => navigate('/create')}>Create one</Button>
               ) : (

--- a/packages/ui/src/pages/Home.tsx
+++ b/packages/ui/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Box, Chip, CircularProgress, Grid, Paper } from '@mui/material'
 import { useMultiProxy } from '../contexts/MultiProxyContext'
 import TransactionList from '../components/Transactions/TransactionList'
@@ -80,11 +80,7 @@ const Home = ({ className }: Props) => {
   const onCloseSendModal = useCallback(() => setIsSendModalOpen(false), [])
   const onCloseEditModal = useCallback(() => setIsEditModalOpen(false), [])
   const onCloseChangeMultiModal = useCallback(() => setIsChangeMultiModalOpen(false), [])
-  const creationInProgress = useMemo(
-    () => searchParams.get('creationInProgress') === 'true',
-    [searchParams]
-  )
-  const [isNewMultisigAlertOpen, setIsNewMultisigAlertOpen] = useState(true)
+  const [showNewMultisigAlert, setShowNewMultisigAlert] = useState(false)
   const {
     isAllowedToConnectToExtension,
     isExtensionError,
@@ -103,9 +99,18 @@ const Home = ({ className }: Props) => {
   }, [refresh])
 
   const onClosenewMultisigAlert = useCallback(() => {
-    setIsNewMultisigAlertOpen(false)
+    setShowNewMultisigAlert(false)
     setSearchParams({ creationInProgress: 'false' })
   }, [setSearchParams])
+
+  useEffect(() => {
+    if (searchParams.get('creationInProgress') === 'true') {
+      setShowNewMultisigAlert(true)
+      setTimeout(() => {
+        onClosenewMultisigAlert()
+      }, 20000)
+    }
+  }, [])
 
   const options: MenuOption[] = useMemo(() => {
     const opts = [
@@ -219,7 +224,7 @@ const Home = ({ className }: Props) => {
         spacing={2}
       >
         <Box className="loader">
-          {creationInProgress ? (
+          {showNewMultisigAlert ? (
             <SuccessCreation />
           ) : (
             <WrapperConnectButtonStyled>
@@ -244,7 +249,7 @@ const Home = ({ className }: Props) => {
       container
       spacing={2}
     >
-      {creationInProgress && multiProxyList.length > 0 && isNewMultisigAlertOpen && (
+      {showNewMultisigAlert && multiProxyList.length > 0 && showNewMultisigAlert && (
         <NewMulisigAlert onClose={onClosenewMultisigAlert} />
       )}
       <Grid


### PR DESCRIPTION
- disable the create button and add loader upon signing the multisig creation
![image](https://github.com/ChainSafe/Multix/assets/33178835/27172828-a9e6-454a-9533-aa79ea3debb3)

- show a watched account if the extension is connected but no account is shared and the watched account has multisigs
- move from h1 (super big) to h3  error message if no account connected and no watched account
- In case your first account ever was created, you'd have the waiting screen, and the info alert afterward still. This fixes it.