### PR TITLE
Fix duplicate multisigs

### DIFF
--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -46,6 +46,7 @@ const getSignatoriesFromAccount = (
 const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
   const [selectedMultiProxy, setSelectedMultiProxy] =
     useState<IMultisigContext['selectedMultiProxy']>(undefined)
+  console.log('selectedMultiProxy', selectedMultiProxy)
   const [multiProxyList, setMultisigList] = useState<IMultisigContext['multiProxyList']>([])
   const { ownAddressList } = useAccounts()
   const { watchedAddresses } = useWatchedAddresses()
@@ -71,8 +72,7 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
       const pureProxyMap = new Map<string, Omit<MultiProxy, 'proxy'>>()
       const res: MultiProxy[] = []
 
-      // FIXME could be pp at this point
-      // iterate through the multisigs
+      // iterate through the multisigs and pure proxies
       data.accounts.forEach((account) => {
         // if the account is a pure proxy
         if (account.isPureProxy) {
@@ -80,6 +80,13 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
           account.delegatorFor.forEach(({ delegatee, type }) => {
             if (delegatee.isMultisig) {
               const previousMultisigsForProxy = pureProxyMap.get(account.id)?.multisigs || []
+
+              const isAlreadyInMultisigList = !!previousMultisigsForProxy.find(
+                ({ address }) => address === delegatee.id
+              )
+
+              // do not add a second time a multisig
+              if (isAlreadyInMultisigList) return
 
               const newMultisigForProxy = {
                 address: delegatee.id,

--- a/packages/ui/src/pages/Help/index.tsx
+++ b/packages/ui/src/pages/Help/index.tsx
@@ -77,13 +77,13 @@ const Help = ({ className }: Props) => {
           </Box>
           <Box className="sectionWrapper">
             <h1>{renderMultisigHeading(hasSeveralMultisigs)}</h1>
-            {selectedMultiProxy?.multisigs.map((multisig) => (
+            {selectedMultiProxy?.multisigs.map((multisig, index) => (
               <Box
                 className="multisigWithProxy"
                 key={multisig.address}
               >
                 <MultisigCompactDisplay
-                  address={selectedMultiProxy?.multisigs[0].address || ''}
+                  address={selectedMultiProxy?.multisigs[index].address || ''}
                   expanded={false}
                 />
                 {getMultisigInfo(multisig)}


### PR DESCRIPTION
closes #227 

- if watching a pure, and the signatory of a multisig, one multisig was duplicated
- another unrelated bug would be showing the 1st multisig twice in the help page

To replicate, watch the following on Kusama:
- Alice u Bob `DGaHm71gRHJGQVF2ubunkx37qgLpno2gYibq2WHoDJpFMt6`
- Chaos Dao Pure proxy `DCZyhphXsRLcW84G9WmWEXtAA8DKGtVGSFZLJYty8Ajjyfa`