### PR TITLE
Hotfix Allow signing when no calldata is needed

### DIFF
--- a/packages/ui/src/components/modals/ProposalSigning.tsx
+++ b/packages/ui/src/components/modals/ProposalSigning.tsx
@@ -1,4 +1,4 @@
-import { Box, CircularProgress, Dialog, DialogContent, DialogTitle, Grid } from '@mui/material'
+import { CircularProgress, Dialog, DialogContent, DialogTitle, Grid } from '@mui/material'
 import { Button, TextFieldStyled } from '../library'
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { styled } from '@mui/material/styles'


### PR DESCRIPTION
When we have a threshold >2 the 2nd (and other non-last) signatories don't actually need to have the call Data.
I'd be better, but it's not needed.

This is a hotfix, but some more love is required.