### PR TITLE
Close button modal nits

### DIFF
--- a/packages/ui/src/components/library/ModalCloseButton.tsx
+++ b/packages/ui/src/components/library/ModalCloseButton.tsx
@@ -3,7 +3,7 @@ import { Close as CloseIcon } from '@mui/icons-material'
 
 interface Props {
   onClose: () => void
-  className: string
+  className?: string
 }
 
 const CloseButton = ({ onClose, className }: Props) => (

--- a/packages/ui/src/components/library/ModalCloseButton.tsx
+++ b/packages/ui/src/components/library/ModalCloseButton.tsx
@@ -3,20 +3,22 @@ import { Close as CloseIcon } from '@mui/icons-material'
 
 interface Props {
   onClose: () => void
+  className: string
 }
 
-export const CloseButton = ({ onClose }: Props) => (
-  <IconButtonStyled
+const CloseButton = ({ onClose, className }: Props) => (
+  <IconButton
     size="small"
     aria-label="close"
     color="inherit"
     onClick={onClose}
+    className={className}
   >
     <CloseIcon fontSize="small" />
-  </IconButtonStyled>
+  </IconButton>
 )
 
-export const IconButtonStyled = styled(IconButton)`
+export const ModalCloseButton = styled(CloseButton)`
   position: absolute;
   right: 0.5rem;
   top: 0.5rem;

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -22,7 +22,7 @@ import { useMultisigProposalNeededFunds } from '../../hooks/useMultisigProposalN
 import { ErrorOutline as ErrorOutlineIcon } from '@mui/icons-material'
 import { useGetSubscanLinks } from '../../hooks/useSubscanLink'
 import { Button } from '../library'
-import { CloseButton } from '../library/CloseButton'
+import { ModalCloseButton } from '../library/ModalCloseButton'
 
 interface Props {
   onClose: () => void
@@ -348,7 +348,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
       open
       className={className}
     >
-      {!isCallStep && <CloseButton onClose={onClose} />}
+      {(!isCallStep || !!callError) && <ModalCloseButton onClose={onClose} />}
       <DialogTitle>Change multisig</DialogTitle>
       <DialogContent
         className="generalContainer"
@@ -482,7 +482,6 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
                 {currentStep === 'selection' ? 'Next' : 'Save'}
               </Button>
             )}
-            {isCallStep && !!callError && <Button onClick={onClose}>Close</Button>}
           </Grid>
         </Grid>
       </DialogContent>

--- a/packages/ui/src/components/modals/EditNames.tsx
+++ b/packages/ui/src/components/modals/EditNames.tsx
@@ -6,7 +6,7 @@ import { useMultiProxy } from '../../contexts/MultiProxyContext'
 import { AccountNames, useAccountNames } from '../../contexts/AccountNamesContext'
 import AccountEditName, { OnChangeArgs } from '../AccountEditName'
 import { renderMultisigHeading } from '../../pages/multisigHelpers'
-import { CloseButton } from '../library/CloseButton'
+import { ModalCloseButton } from '../library/ModalCloseButton'
 
 interface Props {
   onClose: () => void
@@ -53,7 +53,7 @@ const EditNames = ({ onClose, className }: Props) => {
       open
       className={className}
     >
-      <CloseButton onClose={onClose} />
+      <ModalCloseButton onClose={onClose} />
       <DialogTitle>Edit names</DialogTitle>
       <DialogContent className="generalContainer">
         <Grid container>

--- a/packages/ui/src/components/modals/ProposalSigning.tsx
+++ b/packages/ui/src/components/modals/ProposalSigning.tsx
@@ -16,7 +16,7 @@ import { HexString, MultisigStorageInfo } from '../../types'
 import { useGetSubscanLinks } from '../../hooks/useSubscanLink'
 import { getDisplayArgs, getExtrinsicName } from '../../utils'
 import { useCallInfoFromCallData } from '../../hooks/useCallInfoFromCallData'
-import { CloseButton } from '../library/CloseButton'
+import { ModalCloseButton } from '../library/ModalCloseButton'
 
 interface Props {
   onClose: () => void
@@ -240,7 +240,7 @@ const ProposalSigning = ({
       open
       className={className}
     >
-      <CloseButton onClose={onClose} />
+      <ModalCloseButton onClose={onClose} />
       <DialogTitle>Transaction signing</DialogTitle>
       <DialogContent>
         <Grid container>

--- a/packages/ui/src/components/modals/Send.tsx
+++ b/packages/ui/src/components/modals/Send.tsx
@@ -27,7 +27,7 @@ import { useMultisigProposalNeededFunds } from '../../hooks/useMultisigProposalN
 import { useCheckBalance } from '../../hooks/useCheckBalance'
 import { useGetSubscanLinks } from '../../hooks/useSubscanLink'
 import FromCallData from '../EasySetup/FromCallData'
-import { CloseButton } from '../library/CloseButton'
+import { ModalCloseButton } from '../library/ModalCloseButton'
 
 const SEND_TOKEN_MENU = 'Send tokens'
 const FROM_CALL_DATA_MENU = 'From call data'
@@ -279,7 +279,7 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
       open
       className={className}
     >
-      <CloseButton onClose={onClose} />
+      <ModalCloseButton onClose={onClose} />
       <DialogTitle>Send tx</DialogTitle>
       <DialogContent className="generalContainer">
         <Grid container>

--- a/packages/ui/src/hooks/useSigningCallback.tsx
+++ b/packages/ui/src/hooks/useSigningCallback.tsx
@@ -43,8 +43,6 @@ export const useSigningCallback = ({ onSubmitting, onSuccess, onFinalized, onErr
 
         const incomplete = getIncompleteMessage({ event } as EventRecord)
 
-        console.log('incomplete', `${section}.${method}`, incomplete)
-
         // check if multisig or proxy or batch has an error
         if (incomplete) {
           errorInfo = incomplete


### PR DESCRIPTION
- rename the close button to ModalCloseButton because it's specifically styled.
- remove the close button when there's an error in the multisig change. To see this, make the same Tx twice to change a multisig (signatory rotation)
- delete stray console.log