### PR TITLE
Hot fix - option button for multisig without pure proxy

### DIFF
--- a/packages/ui/src/pages/Home.tsx
+++ b/packages/ui/src/pages/Home.tsx
@@ -283,6 +283,7 @@ const Home = ({ className }: Props) => {
                     <MultisigActionMenu
                       setIsSendModalOpen={setIsSendModalOpen}
                       options={options}
+                      withSendButton={!selectedIsWatched}
                     />
                   )}
                 </BoxStyled>

--- a/packages/ui/src/pages/Home.tsx
+++ b/packages/ui/src/pages/Home.tsx
@@ -279,7 +279,7 @@ const Home = ({ className }: Props) => {
               <HeaderStyled>
                 <h3>{renderMultisigHeading(selectedMultiProxy.multisigs.length > 1)}</h3>
                 <BoxStyled>
-                  {!selectedIsWatched && !selectedHasProxy && (
+                  {!selectedHasProxy && (
                     <MultisigActionMenu
                       setIsSendModalOpen={setIsSendModalOpen}
                       options={options}


### PR DESCRIPTION
I don't remember how we broke this, but it sounds old.
We were not showing the the option menu for multisigs without proxy.

What I tested:
- watched accounts (multisig or proxy) have no send button
- watched accounts (multisig or proxy) have an option menu to change names
- owned accounts (multisig or proxy) have a send button