### PR TITLE
Show multisig if they are delegatee for non pure proxies

### DIFF
--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -91,8 +91,11 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
         // iterate through the multisigs and populate the multiproxy map
         // and the list of pure to query
         data.accountMultisigs.forEach(({ multisig }) => {
+          const hasPureDelegation =
+            multisig.delegateeFor.length > 0 &&
+            multisig.delegateeFor.some(({ delegator }) => delegator.isPureProxy)
           // if the multisig is a delegatee for at least one pure
-          if (multisig.delegateeFor.length > 0) {
+          if (hasPureDelegation) {
             // add the pures to the list to query if they are pure proxies
             multisig.delegateeFor.forEach(({ delegator }) => {
               delegator.isPureProxy && pureToQuerySet.add(delegator.address)


### PR DESCRIPTION
I was told on Hydra that this account was a multisig and not showing on Multix `7NJp5SL8d2SGhzwqdD7qnF4Z3VQe4uMefoxWFnQMuGJeLwPw`

I could verify and found the issue. The reason is that this account was delegatee for a non-pure proxy, and my logic had no case for it.