### PR TITLE
Move khala to own processor

### DIFF
--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -116,8 +116,8 @@ export const networkList = {
     chainId: 'khala',
     explorerNetworkName: 'khala',
     rpcUrl: 'wss://khala-api.phala.network/ws',
-    wsGraphqlUrl: 'wss://squid.subsquid.io/multix-large/v/v2/graphql',
-    httpGraphqlUrl: 'https://squid.subsquid.io/multix-large/v/v2/graphql',
+    wsGraphqlUrl: 'wss://squid.subsquid.io/multix-khala/v/v1/graphql',
+    httpGraphqlUrl: 'https://squid.subsquid.io/multix-khala/v/v1/graphql',
     logo: nodesKhalaSVG
   } as NetworkInfo,
   // pendulum: {


### PR DESCRIPTION
Khala has been notoriously slow to sync (>12h compared to <30min for all the others) when a new deployment was made, preventing us from deploying quickly.
While it's not impacted by most of the changes, I moved it to its own processor so that we can deploy quicker.