### PR TITLE
Refactor api context and fix network switching issue

### DIFF
--- a/packages/ui/src/components/AccountDisplay.tsx
+++ b/packages/ui/src/components/AccountDisplay.tsx
@@ -32,7 +32,7 @@ const AccountDisplay = ({
   const { balanceFormatted } = useGetBalance({ address })
   const localName = useMemo(() => getNamesWithExtension(address), [address, getNamesWithExtension])
   const [identity, setIdentity] = useState<DeriveAccountRegistration | null>(null)
-  const { api, isApiReady, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [mainDisplay, setMainDisplay] = useState<string>('')
   const [sub, setSub] = useState<string | null>(null)
   const [encodedAddress, setEncodedAddress] = useState('')
@@ -51,10 +51,6 @@ const AccountDisplay = ({
 
   useEffect(() => {
     if (!api) {
-      return
-    }
-
-    if (!isApiReady) {
       return
     }
 
@@ -83,7 +79,7 @@ const AccountDisplay = ({
       .catch((e) => console.error(e))
 
     return () => unsubscribe && unsubscribe()
-  }, [address, api, isApiReady])
+  }, [address, api])
 
   return (
     <div className={className}>

--- a/packages/ui/src/components/EasySetup/BalancesTransfer.tsx
+++ b/packages/ui/src/components/EasySetup/BalancesTransfer.tsx
@@ -22,7 +22,7 @@ interface Props {
 const BalancesTransfer = ({ className, onSetExtrinsic, onSetErrorMessage, from }: Props) => {
   const accountBase = useAccountBaseFromAccountList()
   const [selected, setSelected] = useState<AccountBaseInfo | undefined>()
-  const { api, isApiReady, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [amountString, setAmountString] = useState('')
   const [amount, setAmount] = useState<BN | undefined>()
   const [amountError, setAmountError] = useState('')
@@ -42,7 +42,7 @@ const BalancesTransfer = ({ className, onSetExtrinsic, onSetErrorMessage, from }
   }, [amount, amountError, hasEnoughFreeBalance, onSetErrorMessage])
 
   useEffect(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       onSetExtrinsic(undefined)
       return
     }
@@ -53,7 +53,7 @@ const BalancesTransfer = ({ className, onSetExtrinsic, onSetErrorMessage, from }
     }
 
     onSetExtrinsic(api.tx.balances.transferKeepAlive(toAddress, amount.toString()))
-  }, [amount, api, chainInfo, isApiReady, onSetExtrinsic, toAddress])
+  }, [amount, api, chainInfo, onSetExtrinsic, toAddress])
 
   const onAddressDestChange = useCallback((account: AccountBaseInfo) => {
     setSelected(account)

--- a/packages/ui/src/components/EasySetup/FromCallData.tsx
+++ b/packages/ui/src/components/EasySetup/FromCallData.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMessage }: Props) => {
-  const { api, isApiReady } = useApi()
+  const { api } = useApi()
   const [pastedCallData, setPastedCallData] = useState<HexString | undefined>(undefined)
   const [callDataError, setCallDataError] = useState('')
   const [isProxyProxyRemoved, setIsProxyProxyRemoved] = useState(false)
@@ -28,7 +28,7 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
   const removeProxyProxyCall = useCallback(
     (call: HexString) => {
       setIsProxyProxyRemoved(false)
-      if (!api || !isApiReady) return call
+      if (!api) return call
 
       if (!isProxySelected) return call
 
@@ -46,7 +46,7 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
       setIsProxyProxyRemoved(true)
       return `0x${call.substring(74)}` as HexString
     },
-    [api, isApiReady, isProxySelected]
+    [api, isProxySelected]
   )
 
   // users may erroneously paste callData from the multisig calldata
@@ -61,7 +61,7 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
   const { extrinsicUrl } = usePjsLinks()
 
   useEffect(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       return
     }
 
@@ -70,7 +70,7 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
     }
 
     onSetExtrinsic(api.tx(callInfo.call))
-  }, [api, pastedCallData, callInfo, isApiReady, onSetExtrinsic])
+  }, [api, pastedCallData, callInfo, onSetExtrinsic])
 
   const onCallDataChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setCallDataError('')

--- a/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
+++ b/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
@@ -106,7 +106,7 @@ const ManualExtrinsic = ({
   extrinsicIndex,
   onSelectFromCallData
 }: Props) => {
-  const { api, isApiReady } = useApi()
+  const { api } = useApi()
   const [palletRPCs, setPalletRPCs] = useState<any[]>([])
   const [callables, setCallables] = useState<any[]>([])
   const [paramFields, setParamFields] = useState<ParamField[] | null>(null)
@@ -247,7 +247,7 @@ const ManualExtrinsic = ({
   )
 
   useEffect(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       return
     }
 
@@ -271,7 +271,7 @@ const ManualExtrinsic = ({
     api,
     areAllParamsFilled,
     callable,
-    isApiReady,
+
     extrinsicIndex,
     onSetErrorMessage,
     onSetExtrinsic,

--- a/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
+++ b/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
@@ -271,7 +271,6 @@ const ManualExtrinsic = ({
     api,
     areAllParamsFilled,
     callable,
-
     extrinsicIndex,
     onSetErrorMessage,
     onSetExtrinsic,

--- a/packages/ui/src/components/Transactions/TransactionList.tsx
+++ b/packages/ui/src/components/Transactions/TransactionList.tsx
@@ -146,11 +146,11 @@ const TransactionList = ({ className }: Props) => {
     isLoading: isLoadingPendingTxs,
     refresh
   } = usePendingTx(selectedMultiProxy)
-  const { api, isApiReady } = useApi()
+  const { api } = useApi()
   const { ownAddressList } = useAccounts()
 
   useEffect(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       return
     }
 
@@ -179,7 +179,7 @@ const TransactionList = ({ className }: Props) => {
         setAggregatedData(timestampObj)
       })
       .catch(console.error)
-  }, [api, pendingTxData, isApiReady, selectedMultiProxy])
+  }, [api, pendingTxData, selectedMultiProxy])
 
   return (
     <Box className={className}>

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -133,7 +133,6 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
   }, [
     api,
     chainInfo,
-
     newMultisigAddress,
     newThreshold,
     oldThreshold,
@@ -180,7 +179,6 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
   }, [
     api,
     chainInfo,
-
     newSignatories,
     newThreshold,
     selectedAccount,
@@ -276,7 +274,6 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
       })
   }, [
     callError,
-
     api,
     selectedAccount,
     secondCall,

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -34,7 +34,7 @@ type Step = 'selection' | 'summary' | 'call1' | 'call2'
 const ChangeMultisig = ({ onClose, className }: Props) => {
   const { getSubscanExtrinsicLink } = useGetSubscanLinks()
   const modalRef = useRef<HTMLDivElement | null>(null)
-  const { isApiReady, api, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const { selectedMultiProxy, getMultisigAsAccountBaseInfo, getMultisigByAddress } = useMultiProxy()
   const { addToast } = useToasts()
   const signCallBack2 = useSigningCallback({
@@ -90,7 +90,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
   const [callError, setCallError] = useState('')
 
   const firstCall = useMemo(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       // console.error('api is not ready')
       return
     }
@@ -133,7 +133,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
   }, [
     api,
     chainInfo,
-    isApiReady,
+
     newMultisigAddress,
     newThreshold,
     oldThreshold,
@@ -143,7 +143,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
   ])
 
   const secondCall = useMemo(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       // console.error('api is not ready')
       return
     }
@@ -180,7 +180,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
   }, [
     api,
     chainInfo,
-    isApiReady,
+
     newSignatories,
     newThreshold,
     selectedAccount,
@@ -248,7 +248,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
       return
     }
 
-    if (!isApiReady || !api) {
+    if (!api) {
       console.error('api is not ready')
       return
     }
@@ -276,7 +276,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
       })
   }, [
     callError,
-    isApiReady,
+
     api,
     selectedAccount,
     secondCall,
@@ -294,7 +294,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
 
   // first we add the new multisig as an any proxy of the pure proxy, signed by the old multisig
   const onFirstCall = useCallback(async () => {
-    if (!isApiReady || !api) {
+    if (!api) {
       console.error('api is not ready')
       return
     }
@@ -321,7 +321,6 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
         onErrorCallback(error.message)
       })
   }, [
-    isApiReady,
     api,
     selectedAccount,
     firstCall,

--- a/packages/ui/src/components/modals/ProposalSigning.tsx
+++ b/packages/ui/src/components/modals/ProposalSigning.tsx
@@ -34,7 +34,7 @@ const ProposalSigning = ({
   onSuccess
 }: Props) => {
   const { getSubscanExtrinsicLink } = useGetSubscanLinks()
-  const { api, isApiReady } = useApi()
+  const { api } = useApi()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { getMultisigByAddress } = useMultiProxy()
   const { selectedAccount, selectedSigner } = useAccounts()
@@ -112,7 +112,7 @@ const ProposalSigning = ({
         return
       }
 
-      if (!isApiReady || !api) {
+      if (!api) {
         const error = 'Api is not ready'
         console.error(error)
         setErrorMessage(error)
@@ -212,7 +212,7 @@ const ProposalSigning = ({
       signatories,
       threshold,
       proposalData,
-      isApiReady,
+
       api,
       selectedAccount,
       multisig,

--- a/packages/ui/src/components/modals/ProposalSigning.tsx
+++ b/packages/ui/src/components/modals/ProposalSigning.tsx
@@ -212,7 +212,6 @@ const ProposalSigning = ({
       signatories,
       threshold,
       proposalData,
-
       api,
       selectedAccount,
       multisig,

--- a/packages/ui/src/components/modals/Send.tsx
+++ b/packages/ui/src/components/modals/Send.tsx
@@ -35,7 +35,7 @@ interface Props {
 
 const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
   const { getSubscanExtrinsicLink } = useGetSubscanLinks()
-  const { api, isApiReady, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { selectedMultiProxy, getMultisigAsAccountBaseInfo, getMultisigByAddress } = useMultiProxy()
   const { selectedAccount, selectedSigner } = useAccounts()
@@ -82,7 +82,7 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
       return
     }
 
-    if (!isApiReady || !api) {
+    if (!api) {
       return
     }
 
@@ -116,7 +116,7 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
   }, [
     api,
     extrinsicToCall,
-    isApiReady,
+    
     isProxySelected,
     selectedAccount,
     selectedMultisig,
@@ -215,7 +215,7 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
       return
     }
 
-    if (!isApiReady || !api) {
+    if (!api) {
       const error = 'Api is not ready'
       console.error(error)
       setErrorMessage(error)
@@ -254,7 +254,7 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
       })
   }, [
     threshold,
-    isApiReady,
+    
     api,
     selectedAccount,
     selectedOrigin,

--- a/packages/ui/src/components/modals/Send.tsx
+++ b/packages/ui/src/components/modals/Send.tsx
@@ -116,7 +116,6 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
   }, [
     api,
     extrinsicToCall,
-    
     isProxySelected,
     selectedAccount,
     selectedMultisig,
@@ -254,7 +253,6 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
       })
   }, [
     threshold,
-    
     api,
     selectedAccount,
     selectedOrigin,

--- a/packages/ui/src/hooks/useCallInfoFromCallData.tsx
+++ b/packages/ui/src/hooks/useCallInfoFromCallData.tsx
@@ -5,7 +5,7 @@ import { GenericCall } from '@polkadot/types'
 import { PAYMENT_INFO_ACCOUNT } from '../constants'
 
 export const useCallInfoFromCallData = (callData?: HexString) => {
-  const { api, isApiReady } = useApi()
+  const { api } = useApi()
   const [callInfo, setCallInfo] = useState<SubmittingCall | undefined>(undefined)
   const [isGettingCallInfo, setIsGettingCallInfo] = useState(false)
 
@@ -15,7 +15,7 @@ export const useCallInfoFromCallData = (callData?: HexString) => {
       return
     }
 
-    if (!api || !isApiReady) {
+    if (!api) {
       setCallInfo(undefined)
       return
     }
@@ -43,7 +43,7 @@ export const useCallInfoFromCallData = (callData?: HexString) => {
       })
       .catch(console.error)
       .finally(() => setIsGettingCallInfo(false))
-  }, [api, callData, isApiReady])
+  }, [api, callData])
 
   return { callInfo, isGettingCallInfo }
 }

--- a/packages/ui/src/hooks/useGetBalance.tsx
+++ b/packages/ui/src/hooks/useGetBalance.tsx
@@ -9,12 +9,12 @@ interface useGetBalanceProps {
   numberAfterComma?: number
 }
 export const useGetBalance = ({ address, numberAfterComma = 4 }: useGetBalanceProps) => {
-  const { isApiReady, api, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [balance, setBalance] = useState<Balance | null>(null)
   const [balanceFormatted, setFormattedBalance] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!isApiReady || !api || !address) return
+    if (!api || !address) return
 
     let unsubscribe: () => void
 
@@ -34,7 +34,7 @@ export const useGetBalance = ({ address, numberAfterComma = 4 }: useGetBalancePr
       .catch(console.error)
 
     return () => unsubscribe && unsubscribe()
-  }, [address, api, chainInfo?.tokenDecimals, chainInfo?.tokenSymbol, isApiReady, numberAfterComma])
+  }, [address, api, chainInfo?.tokenDecimals, chainInfo?.tokenSymbol, numberAfterComma])
 
   return { balance, balanceFormatted }
 }

--- a/packages/ui/src/hooks/useMultisigProposalNeededFunds.tsx
+++ b/packages/ui/src/hooks/useMultisigProposalNeededFunds.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export const useMultisigProposalNeededFunds = ({ threshold, signatories, call }: Props) => {
-  const {  api, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [min, setMin] = useState(new BN(0))
   const [reserved, setReserved] = useState(new BN(0))
 

--- a/packages/ui/src/hooks/useMultisigProposalNeededFunds.tsx
+++ b/packages/ui/src/hooks/useMultisigProposalNeededFunds.tsx
@@ -11,12 +11,12 @@ interface Props {
 }
 
 export const useMultisigProposalNeededFunds = ({ threshold, signatories, call }: Props) => {
-  const { isApiReady, api, chainInfo } = useApi()
+  const {  api, chainInfo } = useApi()
   const [min, setMin] = useState(new BN(0))
   const [reserved, setReserved] = useState(new BN(0))
 
   useEffect(() => {
-    if (!isApiReady || !api || !signatories || signatories.length < 2) return
+    if (!api || !signatories || signatories.length < 2) return
 
     if (!chainInfo?.tokenDecimals) return
 
@@ -48,7 +48,7 @@ export const useMultisigProposalNeededFunds = ({ threshold, signatories, call }:
       console.error('Error in useMultisigProposalNeededFunds')
       console.error(e)
     }
-  }, [api, call, chainInfo, isApiReady, signatories, threshold])
+  }, [api, call, chainInfo, signatories, threshold])
 
   return { multisigProposalNeededFunds: min, reserved }
 }

--- a/packages/ui/src/hooks/usePendingTx.tsx
+++ b/packages/ui/src/hooks/usePendingTx.tsx
@@ -13,7 +13,7 @@ export interface PendingTx {
 }
 export const usePendingTx = (multiProxy?: MultiProxy) => {
   const [isLoading, setIsLoading] = useState(true)
-  const { isApiReady, api } = useApi()
+  const {  api } = useApi()
   const [data, setData] = useState<PendingTx[]>([])
   const multisigs = useMemo(
     () => multiProxy?.multisigs.map(({ address }) => address) || [],
@@ -21,7 +21,7 @@ export const usePendingTx = (multiProxy?: MultiProxy) => {
   )
 
   const refresh = useCallback(() => {
-    if (!isApiReady || !api) return
+    if (!api) return
 
     if (isEmptyArray(multisigs)) return
 
@@ -61,7 +61,7 @@ export const usePendingTx = (multiProxy?: MultiProxy) => {
         setIsLoading(false)
       })
       .catch(console.error)
-  }, [api, isApiReady, multisigs])
+  }, [api, multisigs])
 
   useEffect(() => {
     refresh()

--- a/packages/ui/src/hooks/usePendingTx.tsx
+++ b/packages/ui/src/hooks/usePendingTx.tsx
@@ -13,7 +13,7 @@ export interface PendingTx {
 }
 export const usePendingTx = (multiProxy?: MultiProxy) => {
   const [isLoading, setIsLoading] = useState(true)
-  const {  api } = useApi()
+  const { api } = useApi()
   const [data, setData] = useState<PendingTx[]>([])
   const multisigs = useMemo(
     () => multiProxy?.multisigs.map(({ address }) => address) || [],

--- a/packages/ui/src/hooks/useProxyAdditionNeededFunds.tsx
+++ b/packages/ui/src/hooks/useProxyAdditionNeededFunds.tsx
@@ -3,7 +3,7 @@ import { useApi } from '../contexts/ApiContext'
 import BN from 'bn.js'
 
 export const useProxyAdditionNeededFunds = () => {
-  const {  api, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [min, setMin] = useState(new BN(0))
 
   useEffect(() => {

--- a/packages/ui/src/hooks/useProxyAdditionNeededFunds.tsx
+++ b/packages/ui/src/hooks/useProxyAdditionNeededFunds.tsx
@@ -3,11 +3,11 @@ import { useApi } from '../contexts/ApiContext'
 import BN from 'bn.js'
 
 export const useProxyAdditionNeededFunds = () => {
-  const { isApiReady, api, chainInfo } = useApi()
+  const {  api, chainInfo } = useApi()
   const [min, setMin] = useState(new BN(0))
 
   useEffect(() => {
-    if (!isApiReady || !api) return
+    if (!api) return
 
     if (!chainInfo?.tokenDecimals) return
 
@@ -17,7 +17,7 @@ export const useProxyAdditionNeededFunds = () => {
     // that added the first proxy) we are only adding one account as proxy
     const reserved = api.consts.proxy.proxyDepositFactor as unknown as BN
     setMin(reserved)
-  }, [api, chainInfo, isApiReady])
+  }, [api, chainInfo])
 
   return { proxyAdditionNeededFunds: min }
 }

--- a/packages/ui/src/hooks/usePureProxyCreationNeededFunds.tsx
+++ b/packages/ui/src/hooks/usePureProxyCreationNeededFunds.tsx
@@ -3,11 +3,11 @@ import { useApi } from '../contexts/ApiContext'
 import BN from 'bn.js'
 
 export const usePureProxyCreationNeededFunds = () => {
-  const { isApiReady, api, chainInfo } = useApi()
+  const {  api, chainInfo } = useApi()
   const [min, setMin] = useState(new BN(0))
 
   useEffect(() => {
-    if (!isApiReady || !api) return
+    if (!api) return
 
     if (!chainInfo?.tokenDecimals) return
 
@@ -29,7 +29,7 @@ export const usePureProxyCreationNeededFunds = () => {
 
     setMin(reserved.add(survive))
     // console.log('reserved Pure Creation', formatBnBalance(reserved.add(survive), chainInfo.tokenDecimals, { tokenSymbol: chainInfo?.tokenSymbol, numberAfterComma: 3 }))
-  }, [api, chainInfo, isApiReady])
+  }, [api, chainInfo])
 
   return { pureProxyCreationNeededFunds: min }
 }

--- a/packages/ui/src/hooks/usePureProxyCreationNeededFunds.tsx
+++ b/packages/ui/src/hooks/usePureProxyCreationNeededFunds.tsx
@@ -3,7 +3,7 @@ import { useApi } from '../contexts/ApiContext'
 import BN from 'bn.js'
 
 export const usePureProxyCreationNeededFunds = () => {
-  const {  api, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [min, setMin] = useState(new BN(0))
 
   useEffect(() => {

--- a/packages/ui/src/pages/Creation/index.tsx
+++ b/packages/ui/src/pages/Creation/index.tsx
@@ -28,7 +28,7 @@ const MultisigCreation = ({ className }: Props) => {
   const [signatories, setSignatories] = useState<string[]>([])
   const [currentStep, setCurrentStep] = useState(0)
   const isLastStep = useMemo(() => currentStep === steps.length - 1, [currentStep])
-  const { api, isApiReady, chainInfo } = useApi()
+  const { api, chainInfo } = useApi()
   const [threshold, setThreshold] = useState<number | undefined>()
   const { selectedSigner, selectedAccount, ownAddressList } = useAccounts()
   const navigate = useNavigate()
@@ -64,7 +64,7 @@ const MultisigCreation = ({ className }: Props) => {
     return res
   }, [chainInfo, signatories, threshold])
   const batchCall = useMemo(() => {
-    if (!isApiReady || !api) {
+    if (!api) {
       // console.error('api is not ready')
       return
     }
@@ -105,7 +105,7 @@ const MultisigCreation = ({ className }: Props) => {
     return api.tx.utility.batchAll([transferTx, multiSigProxyCall])
   }, [
     api,
-    isApiReady,
+    
     multiAddress,
     pureProxyCreationNeededFunds,
     selectedAccount,

--- a/packages/ui/src/pages/Creation/index.tsx
+++ b/packages/ui/src/pages/Creation/index.tsx
@@ -103,15 +103,7 @@ const MultisigCreation = ({ className }: Props) => {
     )
 
     return api.tx.utility.batchAll([transferTx, multiSigProxyCall])
-  }, [
-    api,
-    
-    multiAddress,
-    pureProxyCreationNeededFunds,
-    selectedAccount,
-    signatories,
-    threshold
-  ])
+  }, [api, multiAddress, pureProxyCreationNeededFunds, selectedAccount, signatories, threshold])
 
   const { multisigProposalNeededFunds } = useMultisigProposalNeededFunds({
     threshold,

--- a/packages/ui/src/pages/Home/Home.tsx
+++ b/packages/ui/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useCallback, useEffect, useState } from 'react'
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
 import { Box, CircularProgress, Grid } from '@mui/material'
 import { useMultiProxy } from '../../contexts/MultiProxyContext'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -32,7 +32,7 @@ const Home = ({ className }: HomeProps) => {
     error: multisigQueryError
   } = useMultiProxy()
   const { selectedNetworkInfo } = useNetwork()
-  const { isApiReady } = useApi()
+  const { api } = useApi()
   const [showNewMultisigAlert, setShowNewMultisigAlert] = useState(false)
   const {
     isAllowedToConnectToExtension,
@@ -70,7 +70,7 @@ const Home = ({ className }: HomeProps) => {
     )
   }
 
-  if (!isApiReady || isAccountLoading) {
+  if (!api || isAccountLoading) {
     return (
       <Box
         className={className}


### PR DESCRIPTION
closes #243 

I removed the fact that we have to check for both `isApiReady` and `api` to be defined. Makes it for a clearer code.