### PR TITLE
Support chains without a proxy

### DIFF
--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -361,7 +361,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
               >
                 {!hasProxyEnoughFunds && (
                   <Alert severity="warning">
-                    The pure account doesn't have enough funds. It needs at least
+                    The pure account doesn't have enough funds. It needs at least{' '}
                     {formatBnBalance(proxyAdditionNeededFunds, chainInfo?.tokenDecimals, {
                       tokenSymbol: chainInfo?.tokenSymbol
                     })}

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -422,7 +422,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
               signatories={newSignatories}
               threshold={newThreshold}
               proxyAddress={selectedMultiProxy?.proxy}
-              isSwapSummary
+              isCreationSummary={false}
               balanceMin={neededBalance}
               isBalanceError={!hasSignerEnoughFunds}
               selectedMultisig={selectedMultisig}

--- a/packages/ui/src/pages/Creation/Summary.tsx
+++ b/packages/ui/src/pages/Creation/Summary.tsx
@@ -17,7 +17,7 @@ interface Props {
   signatories: string[]
   name?: string
   proxyAddress?: string
-  isSwapSummary?: boolean
+  isCreationSummary?: boolean
   balanceMin?: BN
   isBalanceError?: boolean
   selectedMultisig?: MultiProxy['multisigs'][0] // this is only relevant for swaps
@@ -29,7 +29,7 @@ const Summary = ({
   signatories,
   name,
   proxyAddress,
-  isSwapSummary = false,
+  isCreationSummary = true,
   balanceMin,
   isBalanceError,
   selectedMultisig
@@ -38,29 +38,29 @@ const Summary = ({
   const { chainInfo } = useApi()
 
   const possibleSigners = useMemo(() => {
-    return isSwapSummary
+    return isCreationSummary
       ? // for a swap we can only select the account that are part of both the old and the new multisig
-        getIntersection(ownAddressList, getIntersection(selectedMultisig?.signatories, signatories))
-      : getIntersection(ownAddressList, signatories)
-  }, [ownAddressList, isSwapSummary, selectedMultisig, signatories])
+        getIntersection(ownAddressList, signatories)
+      : getIntersection(ownAddressList, getIntersection(selectedMultisig?.signatories, signatories))
+  }, [ownAddressList, isCreationSummary, selectedMultisig, signatories])
 
-  if (isSwapSummary && !proxyAddress) {
+  if (isCreationSummary && !proxyAddress) {
     console.log('ProxyAddress undefined while being a swap summary')
     return null
   }
 
   return (
     <Box className={className}>
-      {isSwapSummary && proxyAddress ? (
+      {isCreationSummary ? (
+        <h3>You are about to create a Multisig:</h3>
+      ) : (
         <>
           <h3>You are about to change the Multisig controlling:</h3>
           <AccoutDisplayProxyStyled
-            address={proxyAddress}
+            address={proxyAddress || ''}
             badge={AccountBadge.PURE}
           />
         </>
-      ) : (
-        <h3>You are about to create a Multisig:</h3>
       )}
       <Paper
         elevation={2}
@@ -85,16 +85,7 @@ const Summary = ({
       </Paper>
       <Box className="explainer">
         <Alert severity="info">
-          {isSwapSummary ? (
-            <>
-              In the next step you will sign 2 transactions to:
-              <ul>
-                <li>add the new Multisig to the current Pure proxy</li>
-                <li>remove the old Multisig</li>
-              </ul>
-              Other signatories will need to approve these transactions.
-            </>
-          ) : (
+          {isCreationSummary ? (
             <>
               In the next step you will send 1 batch transaction to:
               <ul>
@@ -102,6 +93,15 @@ const Summary = ({
                 <li>create the Pure proxy</li>
               </ul>
               Other signatories will need to approve this transaction.
+            </>
+          ) : (
+            <>
+              In the next step you will sign 2 transactions to:
+              <ul>
+                <li>add the new Multisig to the current Pure proxy</li>
+                <li>remove the old Multisig</li>
+              </ul>
+              Other signatories will need to approve these transactions.
             </>
           )}
         </Alert>

--- a/packages/ui/src/pages/Creation/Summary.tsx
+++ b/packages/ui/src/pages/Creation/Summary.tsx
@@ -21,6 +21,7 @@ interface Props {
   balanceMin?: BN
   isBalanceError?: boolean
   selectedMultisig?: MultiProxy['multisigs'][0] // this is only relevant for swaps
+  withProxy?: boolean
 }
 
 const Summary = ({
@@ -32,7 +33,8 @@ const Summary = ({
   isCreationSummary = true,
   balanceMin,
   isBalanceError,
-  selectedMultisig
+  selectedMultisig,
+  withProxy = true
 }: Props) => {
   const { ownAddressList } = useAccounts()
   const { chainInfo } = useApi()
@@ -44,7 +46,7 @@ const Summary = ({
       : getIntersection(ownAddressList, getIntersection(selectedMultisig?.signatories, signatories))
   }, [ownAddressList, isCreationSummary, selectedMultisig, signatories])
 
-  if (isCreationSummary && !proxyAddress) {
+  if (!isCreationSummary && !proxyAddress) {
     console.log('ProxyAddress undefined while being a swap summary')
     return null
   }
@@ -86,14 +88,18 @@ const Summary = ({
       <Box className="explainer">
         <Alert severity="info">
           {isCreationSummary ? (
-            <>
-              In the next step you will send 1 batch transaction to:
-              <ul>
-                <li>send funds to the new Multisig (required to create a Pure proxy)</li>
-                <li>create the Pure proxy</li>
-              </ul>
-              Other signatories will need to approve this transaction.
-            </>
+            withProxy ? (
+              <>
+                In the next step you will send 1 batch transaction to:
+                <ul>
+                  <li>send funds to the new Multisig (required to create a Pure proxy)</li>
+                  <li>create the Pure proxy</li>
+                </ul>
+                Other signatories will need to approve this transaction.
+              </>
+            ) : (
+              <>In the next step you will sign a remark transaction for the multisig creation</>
+            )
           ) : (
             <>
               In the next step you will sign 2 transactions to:
@@ -114,7 +120,7 @@ const Summary = ({
       </Box>
       {isBalanceError && balanceMin && (
         <Alert severity="warning">
-          The selected signer requires at least
+          The selected signer requires at least{' '}
           {formatBnBalance(balanceMin, chainInfo?.tokenDecimals, {
             tokenSymbol: chainInfo?.tokenSymbol
           })}

--- a/packages/ui/src/pages/Creation/ThresholdSelection.tsx
+++ b/packages/ui/src/pages/Creation/ThresholdSelection.tsx
@@ -1,7 +1,8 @@
-import { Box, InputAdornment } from '@mui/material'
+import { Box, InputAdornment, Tooltip } from '@mui/material'
 import React, { useCallback, useEffect, useState } from 'react'
 import { styled } from '@mui/material/styles'
 import { TextFieldStyled } from '../../components/library'
+import { HiOutlineInformationCircle } from 'react-icons/hi2'
 
 interface Props {
   className?: string
@@ -54,11 +55,14 @@ const ThresholdSelection = ({ className, threshold, setThreshold, signatoriesNum
 
   return (
     <Box className={className}>
+      <TitleBoxStyled>
+        Threshold <InfoBox />
+      </TitleBoxStyled>
       <TextFieldStyled
         fullWidth
         error={!!error}
         helperText={error}
-        label="Threshold"
+        label=""
         InputProps={{
           endAdornment: <InputAdornment position="end">/{signatoriesNumber}</InputAdornment>
         }}
@@ -68,6 +72,24 @@ const ThresholdSelection = ({ className, threshold, setThreshold, signatoriesNum
     </Box>
   )
 }
+
+const InfoBox = ({ className = '' }: { className?: string }) => (
+  <Tooltip
+    className={className}
+    title="The threshold determines the minimum amount of signatory approvals needed for a
+    multisig transaction to be executed."
+  >
+    <span>
+      <HiOutlineInformationCircle />
+    </span>
+  </Tooltip>
+)
+
+const TitleBoxStyled = styled(Box)`
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.custom.text.primary};
+`
 
 export default styled(ThresholdSelection)`
   margin-bottom: 1rem;

--- a/packages/ui/src/pages/Creation/WitProxySelection.tsx
+++ b/packages/ui/src/pages/Creation/WitProxySelection.tsx
@@ -1,0 +1,60 @@
+import { Box, Checkbox, FormControlLabel, Tooltip, styled } from '@mui/material'
+import { HiOutlineInformationCircle } from 'react-icons/hi2'
+
+interface Props {
+  setWithProxy: (withProxy: boolean) => void
+  withProxy: boolean
+  className?: string
+}
+const WithProxySelection = ({ setWithProxy, withProxy, className }: Props) => {
+  return (
+    <Box className={className}>
+      <TitleBoxStyled>
+        Pure proxy <InfoBox />
+      </TitleBoxStyled>
+      <FormControlLabel
+        label="Use a pure proxy (recommended)"
+        control={
+          <Checkbox
+            checked={withProxy}
+            onChange={() => setWithProxy(!withProxy)}
+          />
+        }
+      />
+    </Box>
+  )
+}
+
+const InfoBox = ({ className = '' }: { className?: string }) => (
+  <Tooltip
+    className={className}
+    title={
+      <span>
+        Using a proxy makes the multisig more flexible. You can then change the signatories without
+        changing the proxy address. More info{' '}
+        <a
+          href="https://youtu.be/cQymHtreDUA?t=147"
+          target="_blank"
+          rel="noreferrer"
+        >
+          in this video
+        </a>
+        .
+      </span>
+    }
+  >
+    <span>
+      <HiOutlineInformationCircle />
+    </span>
+  </Tooltip>
+)
+
+const TitleBoxStyled = styled(Box)`
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.custom.text.primary};
+`
+
+export default styled(WithProxySelection)`
+  margin-top: 1rem;
+`


### PR DESCRIPTION
closes https://github.com/ChainSafe/Multix/issues/276

We now add a checkbox in the multisig creation flow for user to choose wether they want a proxy or not. It's checked by default, and won't be visible for chains that don't have the proxy pallet.
Because there's actually nothing to do to create such a simple multisig, what we do is propose to create a system remark, which is super cheap and contains "Multix creation [address]". We need to have at least 1 on-chain transaction from the multisig in order for the indexer to pick it up and know about this new multisig.

Whether this transaction is approved or not is actually irrelevant.. it just shows users what it's like to have a multisig transaction pending then :man_shrugging: 