### PR TITLE
Small refactor to prevent casting selected value.

### DIFF
--- a/packages/ui/src/components/library/Select.tsx
+++ b/packages/ui/src/components/library/Select.tsx
@@ -15,7 +15,7 @@ import { theme } from '../../styles/theme'
 interface SelectProps {
   value: string
   menuItems?: { value: string; logo?: string }[]
-  onChange: (event: SelectChangeEvent<string>) => void
+  onChange: (event: SelectChangeEvent<unknown>) => void
   minified?: boolean
   inputSize?: 'medium' | 'large'
   fullWidth?: boolean
@@ -44,7 +44,7 @@ const Select = ({
       fullWidth={fullWidth}
       IconComponent={HiOutlineChevronDown}
       MenuProps={MenuPropsStyles}
-      onChange={(event) => onChange(event as SelectChangeEvent<string>)}
+      onChange={onChange}
     >
       {menuItems
         ? menuItems.map(({ value, logo }) => (

--- a/packages/ui/src/components/modals/Send.tsx
+++ b/packages/ui/src/components/modals/Send.tsx
@@ -218,11 +218,19 @@ const Send = ({ onClose, className, onSuccess, onFinalized }: Props) => {
     getSubscanExtrinsicLink
   ])
 
-  const onChangeEasySetupOption = useCallback((event: SelectChangeEvent<string>) => {
-    setErrorMessage('')
-    setEasyOptionErrorMessage('')
-    setSelectedEasyOption(event.target.value)
-  }, [])
+  const onChangeEasySetupOption = useCallback(
+    ({ target: { value } }: SelectChangeEvent<unknown>) => {
+      if (typeof value !== 'string') {
+        console.error('Unexpected network value, expect string but received', value)
+        return
+      }
+
+      setErrorMessage('')
+      setEasyOptionErrorMessage('')
+      setSelectedEasyOption(value)
+    },
+    []
+  )
 
   if (!possibleOrigin) {
     return null

--- a/packages/ui/src/components/select/NetworkSelection.tsx
+++ b/packages/ui/src/components/select/NetworkSelection.tsx
@@ -21,7 +21,12 @@ const NetworkSelection = () => {
   }, [])
 
   const handleNetworkSelection = useCallback(
-    ({ target: { value } }: SelectChangeEvent<string>) => {
+    ({ target: { value } }: SelectChangeEvent<unknown>) => {
+      if (typeof value !== 'string') {
+        console.error('Unexpected network value, expect string but received', value)
+        return
+      }
+
       selectNetwork(value)
     },
     [selectNetwork]
@@ -55,7 +60,7 @@ const NetworkSelection = () => {
       IconComponent={HiOutlineChevronDown}
       value={selectedNetwork}
       autoWidth={true}
-      onChange={(event) => handleNetworkSelection(event as SelectChangeEvent<string>)}
+      onChange={handleNetworkSelection}
       MenuProps={MenuPropsStyles}
     >
       <ListSubheader>Polkadot & Parachains</ListSubheader>


### PR DESCRIPTION
Came across the `as SelectChangeEvent<string>` in the code and thought we could do better. It ended up still adding more code than what we had, but it's a little nicer and more generic I think. wdyt @Lykhoyda?