### PR TITLE
Use clock & tick instead of waituntil

### DIFF
--- a/packages/ui/cypress/tests/login.cy.ts
+++ b/packages/ui/cypress/tests/login.cy.ts
@@ -2,18 +2,20 @@ import { injectedAccounts } from '../fixtures/injectedAccounts'
 import { landingPageUrl } from '../fixtures/landingData'
 import { landingPage } from '../support/page-objects/landingPage'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
-import { waitForAuthRequest } from '../utils/waitForAuthRequests'
 
 describe('Connect Account', () => {
   beforeEach(() => {
     cy.visit(landingPageUrl)
     cy.initExtension(injectedAccounts)
+    cy.clock()
     topMenuItems.connectButton().click()
     landingPage.accountsLoader().should('contain', 'Loading accounts')
+    cy.tick(500)
+    // restore the clock to prevent WS errors
+    cy.clock().invoke('restore')
   })
 
   it('Reject connection', () => {
-    waitForAuthRequest()
     cy.getAuthRequests().then((authRequests) => {
       const requests = Object.values(authRequests)
       // we should have 1 connection request to the extension
@@ -28,7 +30,6 @@ describe('Connect Account', () => {
   })
 
   it('Connects with Alice', () => {
-    waitForAuthRequest()
     const AliceAddress = Object.values(injectedAccounts)[0].address
     cy.getAuthRequests().then((authRequests) => {
       const requests = Object.values(authRequests)

--- a/packages/ui/cypress/tests/login.cy.ts
+++ b/packages/ui/cypress/tests/login.cy.ts
@@ -2,17 +2,13 @@ import { injectedAccounts } from '../fixtures/injectedAccounts'
 import { landingPageUrl } from '../fixtures/landingData'
 import { landingPage } from '../support/page-objects/landingPage'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
+import { clickOnConnect } from '../utils/clickOnConnect'
 
 describe('Connect Account', () => {
   beforeEach(() => {
     cy.visit(landingPageUrl)
     cy.initExtension(injectedAccounts)
-    cy.clock()
-    topMenuItems.connectButton().click()
-    landingPage.accountsLoader().should('contain', 'Loading accounts')
-    cy.tick(500)
-    // restore the clock to prevent WS errors
-    cy.clock().invoke('restore')
+    clickOnConnect()
   })
 
   it('Reject connection', () => {

--- a/packages/ui/cypress/tests/transactions.cy.ts
+++ b/packages/ui/cypress/tests/transactions.cy.ts
@@ -6,7 +6,6 @@ import { multisigPage } from '../support/page-objects/multisigPage'
 import { notifications } from '../support/page-objects/notifications'
 import { sendTxModal } from '../support/page-objects/sendTxModal'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
-import { waitForAuthRequest } from '../utils/waitForAuthRequests'
 import { waitForTxRequest } from '../utils/waitForTxRequests'
 
 const AliceAddress = Object.values(injectedAccounts)[0].address
@@ -21,9 +20,12 @@ describe('Perform transactions', () => {
   beforeEach(() => {
     cy.visit(landingPageUrl)
     cy.initExtension(injectedAccounts)
+    cy.clock()
     topMenuItems.connectButton().click()
     landingPage.accountsLoader().should('contain', 'Loading accounts')
-    waitForAuthRequest()
+    cy.tick(500)
+    // restore the clock to prevent WS errors
+    cy.clock().invoke('restore')
     cy.getAuthRequests().then((authRequests) => {
       const requests = Object.values(authRequests)
       // we should have 1 connection request to the extension

--- a/packages/ui/cypress/tests/transactions.cy.ts
+++ b/packages/ui/cypress/tests/transactions.cy.ts
@@ -1,11 +1,11 @@
 import { injectedAccounts } from '../fixtures/injectedAccounts'
 import { knownMultisigs } from '../fixtures/knownMultisigs'
 import { landingPageUrl } from '../fixtures/landingData'
-import { landingPage } from '../support/page-objects/landingPage'
 import { multisigPage } from '../support/page-objects/multisigPage'
 import { notifications } from '../support/page-objects/notifications'
 import { sendTxModal } from '../support/page-objects/sendTxModal'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
+import { clickOnConnect } from '../utils/clickOnConnect'
 import { waitForTxRequest } from '../utils/waitForTxRequests'
 
 const AliceAddress = Object.values(injectedAccounts)[0].address
@@ -20,12 +20,7 @@ describe('Perform transactions', () => {
   beforeEach(() => {
     cy.visit(landingPageUrl)
     cy.initExtension(injectedAccounts)
-    cy.clock()
-    topMenuItems.connectButton().click()
-    landingPage.accountsLoader().should('contain', 'Loading accounts')
-    cy.tick(500)
-    // restore the clock to prevent WS errors
-    cy.clock().invoke('restore')
+    clickOnConnect()
     cy.getAuthRequests().then((authRequests) => {
       const requests = Object.values(authRequests)
       // we should have 1 connection request to the extension

--- a/packages/ui/cypress/utils/clickOnConnect.ts
+++ b/packages/ui/cypress/utils/clickOnConnect.ts
@@ -1,0 +1,11 @@
+import { landingPage } from '../support/page-objects/landingPage'
+import { topMenuItems } from '../support/page-objects/topMenuItems'
+
+export const clickOnConnect = () => {
+  cy.clock()
+  topMenuItems.connectButton().click()
+  landingPage.accountsLoader().should('contain', 'Loading accounts')
+  cy.tick(500)
+  // restore the clock to prevent WS errors
+  cy.clock().invoke('restore')
+}

--- a/packages/ui/cypress/utils/waitForAuthRequests.ts
+++ b/packages/ui/cypress/utils/waitForAuthRequests.ts
@@ -1,2 +1,0 @@
-export const waitForAuthRequest = () =>
-  cy.waitUntil(() => cy.getAuthRequests().then((req) => Object.entries(req).length > 0))


### PR DESCRIPTION
Small refactor to prevent using `waitUntil` when we know there's a setTimeout.