### PR TITLE
Fix value is null

### DIFF
--- a/packages/ui/src/components/CallInfo.tsx
+++ b/packages/ui/src/components/CallInfo.tsx
@@ -88,8 +88,8 @@ const handleBalanceDisplay = ({
 
 const getTypeName = (index: number, name: string, value: any, api: ApiPromise) => {
   const [palletFromName, methodFromName] = name.split('.')
-  const pallet = value.section || palletFromName
-  const method = value.method || methodFromName
+  const pallet = value?.section || palletFromName
+  const method = value?.method || methodFromName
   const metaArgs = !!pallet && !!method && api.tx[pallet][method].meta.args
 
   return (

--- a/packages/ui/src/components/EasySetup/FromCallData.tsx
+++ b/packages/ui/src/components/EasySetup/FromCallData.tsx
@@ -30,8 +30,6 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
       setIsProxyProxyRemoved(false)
       if (!api) return call
 
-      if (!isProxySelected) return call
-
       const proxyProxyString = u8aToHex(api?.tx.proxy?.proxy.callIndex).toString()
 
       // check if this call is a proxy.proxy
@@ -46,7 +44,7 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
       setIsProxyProxyRemoved(true)
       return `0x${call.substring(74)}` as HexString
     },
-    [api, isProxySelected]
+    [api]
   )
 
   // users may erroneously paste callData from the multisig calldata
@@ -106,12 +104,12 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
         error={!!callDataError}
         fullWidth
       />
-      {!!pastedCallData && !!pastedCallInfo && !callDataError && (
+      {!!callInfo && !!pastedCallInfo && !callDataError && (
         <CallInfo
           aggregatedData={{
-            args: getDisplayArgs(pastedCallInfo.call),
-            callData: pastedCallData,
-            name: getExtrinsicName(pastedCallInfo.section, pastedCallInfo.method)
+            args: getDisplayArgs(callInfo.call),
+            callData: callDataToUse,
+            name: getExtrinsicName(callInfo.section, callInfo.method)
           }}
           expanded
           withProxyFiltered={false}


### PR DESCRIPTION
Hotfix for a bug in prod... because of `any` :roll_eyes: 

With for instance `0x1a00181400c502008500042c0f5205000000000000000000001400c902000500042c0f5205000000000000000000001400cd02008500042c0f5205000000000000000000001400d102008500042c0f5205000000000000000000001400d502008500042c0f5205000000000000000000001400d902008500042c0f520500000000000000000000`

We had 
![image](https://github.com/ChainSafe/Multix/assets/33178835/246b28aa-5ef7-4589-8d68-c94ae3c25aa6)
