### PR TITLE
Handle RuntimeCall the same way as Vec<RuntimeCall> 

### DIFF
--- a/packages/ui/src/components/CallInfo.tsx
+++ b/packages/ui/src/components/CallInfo.tsx
@@ -142,7 +142,6 @@ const createUlTree = ({ name, args, decimals, unit, api, typeName }: CreateTreeP
           )
         }
 
-        typeof value === 'object' && console.log('calling with typename, args', _typeName, value)
         return (
           <li key={`${key}-root-${index}`}>
             {key}:{' '}

--- a/packages/ui/src/components/CallInfo.tsx
+++ b/packages/ui/src/components/CallInfo.tsx
@@ -115,12 +115,10 @@ const createUlTree = ({ name, args, decimals, unit, api, typeName }: CreateTreeP
   if (!args) return
   if (!name) return
 
-  // console.log('args', args)
   return (
     <ul className="params">
       {Object.entries(args).map(([key, value], index) => {
         const _typeName = typeName || getTypeName(index, name, api)
-        console.log('typename, key, val', _typeName, key, value)
 
         if (_typeName === 'Vec<RuntimeCall>') {
           return handleBatchDisplay({ value, decimals, unit, api, key: `${key}-batch` })

--- a/packages/ui/src/components/EasySetup/FromCallData.tsx
+++ b/packages/ui/src/components/EasySetup/FromCallData.tsx
@@ -99,7 +99,7 @@ const FromCallData = ({ className, onSetExtrinsic, isProxySelected, onSetErrorMe
       <TextFieldStyled
         label={`Call data`}
         onChange={onCallDataChange}
-        value={pastedCallData}
+        value={pastedCallData || ''}
         helperText={callDataError}
         error={!!callDataError}
         fullWidth


### PR DESCRIPTION
Follow-up to https://github.com/ChainSafe/Multix/pull/399

Things like the following where not displayed nicely (in the tx list, not in the "from call data" because or the removal of the `proxy.proxy`) and a bunch of errors were fired in the console. 

`0x1e00004e899a75c0571af8e2721e8d4c7cfe2206c0e63bc1db88b3e7ef69846d1591720018000c0407004e899a75c0571af8e2721e8d4c7cfe2206c0e63bc1db88b3e7ef69846d1591720b00b04e2bde6f0000187365636f6e640000146f74686572`