### PR TITLE
Update test fixtures for watched account tests

### DIFF
--- a/packages/ui/cypress/fixtures/watchAccounts/watchMultisigs.ts
+++ b/packages/ui/cypress/fixtures/watchAccounts/watchMultisigs.ts
@@ -3,7 +3,7 @@ import { watchSignatories } from './watchSignatories'
 export const watchMultisigs = {
   'multisig-with-pure': {
     name: 'Multisig With Pure',
-    address: '5Fa3UUF3S6SVdXZtPrCw2tGUqxJiRJLxEGfujozfZ4xFeAKn',
+    address: '5EwAYK9noidJUqDXT7RmDABzh8Ag1PEd4HWy9DW82KU3H6tq',
     pureAddress: '5EfdqwwuyjjtEa4UhdjbZJu3UxHEHbzh8LMRvE13xTD7z6Wd',
     threshold: 2,
     signatories: [watchSignatories[0].address, watchSignatories[1].address]

--- a/packages/ui/cypress/fixtures/watchAccounts/watchSignatories.ts
+++ b/packages/ui/cypress/fixtures/watchAccounts/watchSignatories.ts
@@ -7,7 +7,7 @@ export const watchSignatories = [
     mnemonic: 'citizen heavy warrior cattle enter chef label split differ seek turtle gorilla'
   },
   {
-    address: '5EkbU3anZKYP98aXF5MvmCUxvwvM4kxp7osc2Xhj1wHYL6ym',
+    address: '5E9XHcUfeDCL2HEvH8c8rcfroNDSzbLwhV5A1fq7J7RUwAkd',
     name: 'Pure Signatory 2',
     type: 'sr25519',
     mnemonic: 'script spoon elder spawn kite burst theme property hip fatal flight amount'


### PR DESCRIPTION
Realized that one of the signatories in the test fixtures had the incorrect address for the mnemonic being specified. 

Rotated in the account for the mnemonic here (then updated the other fixture with the new multisig address). 