### PR TITLE
Manual reconnect button

### DIFF
--- a/packages/ui/src/hooks/useDisplayError.tsx
+++ b/packages/ui/src/hooks/useDisplayError.tsx
@@ -5,7 +5,7 @@ import {
 
 import { styled } from '@mui/material/styles'
 import { useAccounts } from '../contexts/AccountsContext'
-import { Link } from '../components/library'
+import { Button, Link } from '../components/library'
 import { Center } from '../components/layout/Center'
 import { useWatchedAddresses } from '../contexts/WatchedAddressesContext'
 import { useMultiProxy } from '../contexts/MultiProxyContext'
@@ -13,7 +13,7 @@ import { useMultiProxy } from '../contexts/MultiProxyContext'
 export const useDisplayError = () => {
   const { isExtensionError, isAccountLoading } = useAccounts()
   const { watchedAddresses } = useWatchedAddresses()
-  const { error: multisigQueryError } = useMultiProxy()
+  const { error: multisigQueryError, refetch } = useMultiProxy()
 
   if (isExtensionError && watchedAddresses.length === 0 && !isAccountLoading) {
     return (
@@ -41,7 +41,8 @@ export const useDisplayError = () => {
       <CenterStyled>
         <ErrorMessageStyled>
           <ErrorOutlineIcon size={64} />
-          <div>An error occurred.</div>
+          <div>Connection timed out.</div>
+          <Button onClick={refetch}>Reconnect</Button>
         </ErrorMessageStyled>
       </CenterStyled>
     )
@@ -67,4 +68,8 @@ const CenterStyled = styled(Center)`
 const ErrorMessageStyled = styled('div')`
   text-align: center;
   margin-top: 1rem;
+
+  button {
+    margin-top: 1rem;
+  }
 `

--- a/packages/ui/src/hooks/useMultisigCallsSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigCallsSubscription.tsx
@@ -42,7 +42,7 @@ export const useMultisigCallSubscription = ({ onUpdate, multisigIds }: Args) => 
     )
   }
 
-  const { isError, error, refetch } = useSubscription(
+  useSubscription(
     [`KeyMultisigCallsByMultisigId-${multisigIds}-${selectedNetwork}`],
     () => {
       if (!client) return new Observable<null>()
@@ -59,10 +59,10 @@ export const useMultisigCallSubscription = ({ onUpdate, multisigIds }: Args) => 
     {
       onData: () => {
         onUpdate()
+      },
+      onError(error) {
+        console.error('MultisigCallsByMultisigId subscription error', error)
       }
-      // onError(error) {
-      //   console.error('MultisigCallsByMultisigId subscription error', error)
-      // },
       // retry: (failureCount: number, error: Error) => {
       //   console.error(
       //     'Subscription MultisigCallsByMultisigId failed',
@@ -76,10 +76,10 @@ export const useMultisigCallSubscription = ({ onUpdate, multisigIds }: Args) => 
     }
   )
 
-  if (isError) {
-    console.error('Subscription MultisigCallsByMultisigId error, refetching', error)
-    refetch()
-  }
+  // if (isError) {
+  //   console.error('Subscription MultisigCallsByMultisigId error, refetching', error)
+  //   refetch()
+  // }
 
   // if (isSubsriptionLoading) {
   //     console.log('subscription loading', multisigs);

--- a/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
@@ -54,7 +54,7 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
     )
   }
 
-  const { isError, error, data, isLoading, refetch } = useSubscription(
+  const { error, data, isLoading, refetch } = useSubscription(
     [`KeyMultisigsBySignatoriesOrWatched-${accountIds}-${watchedAccountIds}-${selectedNetwork}`],
     () => {
       if (!client) return new Observable<null>()
@@ -72,10 +72,10 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
     {
       onData(data) {
         !!data && onUpdate(data)
+      },
+      onError(error) {
+        console.error('MultisigsBySignatoriesOrWatched subscription error', error)
       }
-      // onError(error) {
-      //   console.error('MultisigsBySignatoriesOrWatched subscription error', error)
-      // },
       // retry: (failureCount: number, error: Error) => {
       //   console.error(
       //     'Subscription MultisigsBySignatoriesOrWatched failed',
@@ -89,10 +89,10 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
     }
   )
 
-  if (isError) {
-    console.error('Subscription MultisigsBySignatoriesOrWatched error, refetching', error)
-    refetch()
-  }
+  // if (isError) {
+  //   console.error('Subscription MultisigsBySignatoriesOrWatched error, refetching', error)
+  //   refetch()
+  // }
 
   // if (isSubsriptionLoading) {
   //     console.log('subscription loading', multisigs);
@@ -105,5 +105,5 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
   // console.log('subscription data', data)
   //   return <div>Data: {JSON.stringify(data?.multisigCalls)}</div>;
 
-  return { data, isLoading: hasSomethingToQuery && isLoading, error }
+  return { data, isLoading: hasSomethingToQuery && isLoading, error, refetch }
 }

--- a/packages/ui/src/hooks/usePureByIdSubscription.tsx
+++ b/packages/ui/src/hooks/usePureByIdSubscription.tsx
@@ -43,7 +43,7 @@ export const usePureByIdsSubscription = ({ onUpdate, pureIds }: Args) => {
     )
   }
 
-  const { isError, error, data, isLoading, refetch } = useSubscription(
+  const { error, data, isLoading, refetch } = useSubscription(
     [`KeyWatchedPureById-${pureIds}-${selectedNetwork}`],
     () => {
       if (!client) return new Observable<null>()
@@ -60,10 +60,10 @@ export const usePureByIdsSubscription = ({ onUpdate, pureIds }: Args) => {
     {
       onData(data) {
         !!data && onUpdate(data)
+      },
+      onError(error) {
+        console.error('WatchedPureById subscription error', error)
       }
-      // onError(error) {
-      //   console.error('WatchedPureById subscription error', error)
-      // },
       // retry: (failureCount: number, error: Error) => {
       //   console.error(
       //     'Subscription WatchedPureById failed',
@@ -77,10 +77,10 @@ export const usePureByIdsSubscription = ({ onUpdate, pureIds }: Args) => {
     }
   )
 
-  if (isError) {
-    console.error('Subscription WatchedPureById error, refetching', error)
-    refetch()
-  }
+  // if (isError) {
+  //   console.error('Subscription WatchedPureById error, refetching', error)
+  //   refetch()
+  // }
 
   // if (isSubsriptionLoading) {
   //     console.log('subscription loading', multisigs);
@@ -93,5 +93,5 @@ export const usePureByIdsSubscription = ({ onUpdate, pureIds }: Args) => {
   // console.log('subscription data', data)
   //   return <div>Data: {JSON.stringify(data?.multisigCalls)}</div>;
 
-  return { data, isLoading: hasSomethingToQuery && isLoading, error }
+  return { data, isLoading: hasSomethingToQuery && isLoading, error, refetch }
 }


### PR DESCRIPTION
related to #400 

After exploring many other potential issues this could come from (generally more complex as well), I'm exploring one that could be the automatic refresh that can't be stopped and could actually spam our server.

I'm therefore removing the auto-refresh that I implemented a while ago, and add a better copy + reconnect button that hopefully makes the life of the couple affected persons better than previously. We will see if the spikes of demand on the server ever decrease. It's a shot in the dark unfortunately.

To test and see the error, change in `constants.ts` the `wsGraphqlUrl` of a network to point to v6 (it's offline) instead of v7, and visit this network.

![image](https://github.com/ChainSafe/Multix/assets/33178835/5f609d69-ea11-42ce-9b6c-3bc32d6ecc72)
