### PR TITLE
Use Rhala on rococo

### DIFF
--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -158,7 +158,7 @@ export const networkList = {
   'rhala testnet': {
     chainId: 'rhala',
     explorerNetworkName: '',
-    rpcUrl: 'wss://subbridge-test.phala.network/rhala/ws',
+    rpcUrl: 'wss://rhala-node.phala.network/ws',
     wsGraphqlUrl: 'wss://squid.subsquid.io/multix-arrow/v/v2/graphql',
     httpGraphqlUrl: 'https://squid.subsquid.io/multix-arrow/v/v2/graphql',
     logo: nodesKhalaSVG

--- a/squid/squid-manifests/large-squid.yaml
+++ b/squid/squid-manifests/large-squid.yaml
@@ -22,8 +22,8 @@ deploy:
       cmd: ['sqd', 'start-polkadot']
     - name: phala-processor
       cmd: ['sqd', 'start-phala']
-    # - name: rhala-processor
-    #   cmd: ['sqd', 'start-rhala']
+    - name: rhala-processor
+      cmd: ['sqd', 'start-rhala']
     - name: acala-processor
       cmd: ['sqd', 'start-acala']
     - name: bifrost-polkadot-processor


### PR DESCRIPTION
closes #441 
The phala team is now using a new endpoint, after the previous testnet was bricked.
This is already deployed and can be tested live.