### PR TITLE
fix: menu item wrong displaying in Safari

### DIFF
--- a/packages/ui/src/components/select/NetworkSelection.tsx
+++ b/packages/ui/src/components/select/NetworkSelection.tsx
@@ -34,22 +34,26 @@ const NetworkSelection = () => {
   )
 
   const renderNetworks = useCallback(
-    (allowedNetworks: string[]) =>
-      networksToShow
-        .filter(([networkName]) => allowedNetworks.includes(networkName))
-        .map(([networkName, { logo }]) => (
-          <MenuItemStyled
-            key={networkName}
-            value={networkName}
-            data-cy={`select-network-option-${networkName}`}
-          >
-            <ImgStyled
-              alt={`network-logo-${networkName}`}
-              src={logo}
-            />
-            <ItemNameStyled>{networkName}</ItemNameStyled>
-          </MenuItemStyled>
-        )),
+    (allowedNetworks: string[]) => {
+      const filteredNetworks = networksToShow.filter(([networkName]) =>
+        allowedNetworks.includes(networkName)
+      )
+
+      return filteredNetworks.map(([networkName, { logo }]) => (
+        <MenuItemStyled
+          key={networkName}
+          value={networkName}
+          data-cy={`select-network-option-${networkName}`}
+          isOneLine={filteredNetworks.length === 1}
+        >
+          <ImgStyled
+            alt={`network-logo-${networkName}`}
+            src={logo}
+          />
+          <ItemNameStyled>{networkName}</ItemNameStyled>
+        </MenuItemStyled>
+      ))
+    },
     [networksToShow]
   )
 
@@ -186,11 +190,13 @@ const SelectStyled = styled(SelectMui)`
   }
 `
 
-const MenuItemStyled = styled(MenuItem)`
+const MenuItemStyled = styled(MenuItem)<{ isOneLine: boolean }>`
   text-transform: capitalize;
   padding: 0.75rem;
   max-width: 9.1875rem;
   box-sizing: content-box;
+  // Fix for correct display of the one line networks list in Safari
+  ${({ isOneLine }) => isOneLine && 'column-span: all'}
 `
 
 const ImgStyled = styled('img')`

--- a/packages/ui/src/components/select/NetworkSelection.tsx
+++ b/packages/ui/src/components/select/NetworkSelection.tsx
@@ -35,16 +35,16 @@ const NetworkSelection = () => {
 
   const renderNetworks = useCallback(
     (allowedNetworks: string[]) => {
-      const filteredNetworks = networksToShow.filter(([networkName]) =>
+      const displayedNetworks = networksToShow.filter(([networkName]) =>
         allowedNetworks.includes(networkName)
       )
 
-      return filteredNetworks.map(([networkName, { logo }]) => (
+      return displayedNetworks.map(([networkName, { logo }]) => (
         <MenuItemStyled
           key={networkName}
           value={networkName}
           data-cy={`select-network-option-${networkName}`}
-          isOneLine={filteredNetworks.length === 1}
+          isOneLine={displayedNetworks.length === 1}
         >
           <ImgStyled
             alt={`network-logo-${networkName}`}


### PR DESCRIPTION
closes #443 

As a Joystream element is alone in the list, It weirdly splits the element into two columns in Safari. Added the fix for one network in the list.
