### PR TITLE
Add ability to init the wallet with a predefined allowed origin 

### DIFF
--- a/packages/ui/cypress/support/Extension.ts
+++ b/packages/ui/cypress/support/Extension.ts
@@ -39,7 +39,7 @@ export class Extension {
     this.allowedOrigins = {}
   }
 
-  init = async (accounts: InjectedAccountWitMnemonic[]) => {
+  init = async (accounts: InjectedAccountWitMnemonic[], allowedOrigin?: string) => {
     this.reset()
     this.accounts = accounts
     await cryptoWaitReady()
@@ -48,6 +48,12 @@ export class Extension {
       // we only add to the keyring the accounts with a known mnemonic
       !!mnemonic && this.keyring?.addFromUri(mnemonic)
     })
+
+    const accountAddresses = accounts.map(({ address }) => address)
+    // if passed along all the accounts will be allowed for this origin
+    if (allowedOrigin) {
+      this.allowedOrigins[allowedOrigin] = accountAddresses
+    }
   }
 
   getInjectedEnable = () => {
@@ -92,7 +98,7 @@ export class Extension {
           })
 
           // this origin has already allowed some accounts
-          if (this.allowedOrigins[origin]?.length) {
+          if (this.allowedOrigins[origin]) {
             // return the list of accounts
             const res = resolvedObject(
               this.accounts.filter(({ address }) => this.allowedOrigins[origin].includes(address))

--- a/packages/ui/cypress/support/commands.ts
+++ b/packages/ui/cypress/support/commands.ts
@@ -7,6 +7,8 @@ import 'cypress-wait-until'
 
 const LOCALSTORAGE_ACCOUNT_NAMES_KEY = 'multix.accountNames'
 const LOCALSTORAGE_WATCHED_ACCOUNTS_KEY = 'multix.watchedAccount'
+const LOCALSTORAGE_EXTENSION_CONNECTION_KEY = 'multix.canConnectToExtension'
+
 // ***********************************************
 // This example commands.ts shows you how to
 // create various custom commands and overwrite
@@ -49,25 +51,17 @@ const Account1 = testAccounts['Multisig Member Account 1'].address
 
 const injectExtension = (win: Cypress.AUTWindow, extension: Extension) => {
   Object.defineProperty(win, 'injectedWeb3', {
-    get: () => extension.getInjectedEnable()
+    get: () => extension.getInjectedEnable(),
+    set: () => {}
   })
 }
-Cypress.Commands.add('initExtension', (accounts: InjectedAccountWitMnemonic[]) => {
+
+Cypress.Commands.add('initExtension', (accounts: InjectedAccountWitMnemonic[], origin?: string) => {
   cy.log('Initializing extension')
-  cy.wrap(extension.init(accounts))
+  cy.wrap(extension.init(accounts, origin))
 
   return cy.window().then((win) => {
     injectExtension(win, extension)
-  })
-})
-
-Cypress.Commands.add('visitWithInjectedExtension', (url: string) => {
-  cy.log('Extension enabled')
-
-  return cy.visit(url, {
-    onLoad(win) {
-      injectExtension(win, extension)
-    }
   })
 })
 
@@ -113,11 +107,19 @@ interface IVisitWithLocalStorage {
   url: string
   watchedAccounts?: string[]
   accountNames?: Record<string, string>
+  extensionConnectionAllowed?: boolean
+  injectedAccountsExtension?: InjectedAccountWitMnemonic[]
 }
 
 Cypress.Commands.add(
   'visitWithLocalStorage',
-  ({ url, watchedAccounts, accountNames }: IVisitWithLocalStorage) => {
+  ({
+    url,
+    watchedAccounts,
+    accountNames,
+    extensionConnectionAllowed,
+    injectedAccountsExtension
+  }: IVisitWithLocalStorage) => {
     return cy.visit(url, {
       onBeforeLoad(win) {
         !!watchedAccounts?.length &&
@@ -127,6 +129,14 @@ Cypress.Commands.add(
           )
         !!accountNames &&
           win.localStorage.setItem(LOCALSTORAGE_ACCOUNT_NAMES_KEY, JSON.stringify(accountNames))
+
+        !!extensionConnectionAllowed &&
+          win.localStorage.setItem(LOCALSTORAGE_EXTENSION_CONNECTION_KEY, 'true')
+
+        if (injectedAccountsExtension) {
+          extension.init(injectedAccountsExtension, 'Multix')
+          injectExtension(win, extension)
+        }
       }
     })
   }
@@ -136,18 +146,23 @@ declare global {
   namespace Cypress {
     interface Chainable {
       /**
-       * Initialized the Polkadot extension.
+       * Initialized the Polkadot extension. If an origin is passed there is no need to authorize the first connection
        * @param {InjectedAccount[]} accounts - Accounts to load into the extension.
-       * @example cy.initExtension([{ address: '7NPoMQbiA6trJKkjB35uk96MeJD4PGWkLQLH7k7hXEkZpiba', name: 'Alice', type: 'sr25519'}])
+       * @param {string | undefined} origin - Dapp name to automatically share accounts without needing to authorize
+       * @param {string} origin - Dapp name to allow the accounts for automatically
+       * @example cy.initExtension([{ address: '7NPoMQbiA6trJKkjB35uk96MeJD4PGWkLQLH7k7hXEkZpiba', name: 'Alice', type: 'sr25519'}], 'Multix')
        */
-      initExtension: (accounts: InjectedAccountWitMnemonic[]) => Chainable<AUTWindow>
+      initExtension: (
+        accounts: InjectedAccountWitMnemonic[],
+        origin?: string
+      ) => Chainable<AUTWindow>
 
       /**
        * Visit a page with extension injected. It needs to be initialized first.
        * @param {string} url - Page to visit.
        * @example cy.visitWithInjectedExtension('http://localhost:3333')
        */
-      visitWithInjectedExtension: (url: string) => Chainable<AUTWindow>
+      // visitWithInjectedExtension: (url: string) => Chainable<AUTWindow>
 
       /**
        * Read the authentication request queue.
@@ -219,7 +234,15 @@ declare global {
        * @param {string} params.url - Url to visit
        * @param {string[]} params.watchedAccounts - List of public keys of accounts to watch
        * @param {{[publicKey: string]: string}} params.accountNames - Object of addresses associated to names
-       * @example cy.visitWithLocalStorage({url: http://localhost:3333, watchedAccounts: ['0x0c691601793de060491dab143dfae19f5f6413d4ce4c363637e5ceacb2836a4e'], watchedAccounts: {"0x0c691601793de060491dab143dfae19f5f6413d4ce4c363637e5ceacb2836a4e":"my custom name"}})
+       * @param {boolean} params.extensionConnectionAllowed - whether the extension was previously allowed to connect to the website
+       * @param {InjectedAccountWitMnemonic} params.injectedAccountsExtension - Init and inject these account
+       * @example cy.visitWithLocalStorage({
+       *            injectedAccountsExtension: [],
+       *            extensionConnectionAllowed: false,
+       *            url: http://localhost:3333,
+       *            watchedAccounts: ['0x0c691601793de060491dab143dfae19f5f6413d4ce4c363637e5ceacb2836a4e'],
+       *            watchedAccounts: {"0x0c691601793de060491dab143dfae19f5f6413d4ce4c363637e5ceacb2836a4e":"my custom name"}
+       *          })
        */
       visitWithLocalStorage: (params: IVisitWithLocalStorage) => void
     }

--- a/packages/ui/cypress/tests/address-bar.cy.ts
+++ b/packages/ui/cypress/tests/address-bar.cy.ts
@@ -1,27 +1,12 @@
 import { knownMultisigs } from '../fixtures/knownMultisigs'
 import { landingPageAddressUrl, landingPageUrl } from '../fixtures/landingData'
-import { InjectedAccountWitMnemonic, testAccounts } from '../fixtures/testAccounts'
+import { testAccounts } from '../fixtures/testAccounts'
 import { watchMultisigs } from '../fixtures/watchAccounts/watchMultisigs'
 import { watchSignatories } from '../fixtures/watchAccounts/watchSignatories'
 import { accountDisplay } from '../support/page-objects/components/accountDisplay'
 import { landingPage } from '../support/page-objects/landingPage'
 import { multisigPage } from '../support/page-objects/multisigPage'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
-import { clickOnConnect } from '../utils/clickOnConnect'
-
-const initConnectAndRefreshWithAddress = (
-  initAccounts: InjectedAccountWitMnemonic[],
-  connectedAddresses: string[],
-  addressUrl?: string
-) => {
-  cy.visit(landingPageUrl)
-  cy.initExtension(Object.values(initAccounts))
-  clickOnConnect()
-  cy.connectAccounts(connectedAddresses)
-
-  //refresh the page now that the extension is allowed to connect
-  cy.visitWithInjectedExtension(addressUrl ? landingPageAddressUrl(addressUrl) : landingPageUrl)
-}
 
 describe('Account address in the address bar', () => {
   it('shows multi and update address with 1 watched (multi), 0 connected account, no linked address', () => {
@@ -44,11 +29,11 @@ describe('Account address in the address bar', () => {
   it('shows multi and update address with 0 watched, 1 connected account (multi), no linked address', () => {
     const { address } = knownMultisigs['test-multisig-1']
 
-    initConnectAndRefreshWithAddress(
-      [testAccounts['Multisig Member Account 1']],
-      [testAccounts['Multisig Member Account 1'].address],
-      undefined
-    )
+    cy.visitWithLocalStorage({
+      url: landingPageUrl,
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [testAccounts['Multisig Member Account 1']]
+    })
 
     cy.url({ timeout: 10000 }).should('include', address)
     topMenuItems.multiproxySelectorInput().should('have.value', address)
@@ -116,11 +101,12 @@ describe('Account address in the address bar', () => {
     const { address } = knownMultisigs['test-multisig-1']
     const nonMulitisigAccountAddress = testAccounts['Non Multisig Member 1'].address
 
-    initConnectAndRefreshWithAddress(
-      [testAccounts['Multisig Member Account 1']],
-      [testAccounts['Multisig Member Account 1'].address],
-      nonMulitisigAccountAddress
-    )
+    cy.visitWithLocalStorage({
+      url: landingPageAddressUrl(nonMulitisigAccountAddress),
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [testAccounts['Multisig Member Account 1']]
+    })
+
     landingPage.linkedAddressNotFound().should('contain.text', "The linked address can't be found")
     cy.url().should('include', nonMulitisigAccountAddress)
     topMenuItems.multiproxySelector().should('be.visible')
@@ -189,11 +175,12 @@ describe('Account address in the address bar', () => {
 
   it('shows a pure with 0 watched, 1 connected account (many multi & pure), pure linked address', () => {
     const expectedPureAddress = '5EXePPDNnucmLgrirMPQatFfu4WjncVbVoDZXx1gq75e3JcF'
-    initConnectAndRefreshWithAddress(
-      [testAccounts['Many Multisig And Pure Member 1']],
-      [testAccounts['Many Multisig And Pure Member 1'].address],
-      expectedPureAddress
-    )
+    cy.visitWithLocalStorage({
+      url: landingPageAddressUrl(expectedPureAddress),
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [testAccounts['Many Multisig And Pure Member 1']]
+    })
+
     cy.url().should('include', expectedPureAddress)
     topMenuItems.multiproxySelectorInput().should('have.value', expectedPureAddress)
     multisigPage.accountHeader().within(() => {
@@ -203,11 +190,13 @@ describe('Account address in the address bar', () => {
 
   it('shows a multi with 0 watched, 1 connected account (many multi & pure), multi linked address', () => {
     const expectedMultiAddress = '5DxNgjvfJLfDTAAgFD1kWtJAh2KVNTTkwytr7S37dZwVpXd7'
-    initConnectAndRefreshWithAddress(
-      [testAccounts['Many Multisig And Pure Member 1']],
-      [testAccounts['Many Multisig And Pure Member 1'].address],
-      expectedMultiAddress
-    )
+
+    cy.visitWithLocalStorage({
+      url: landingPageAddressUrl(expectedMultiAddress),
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [testAccounts['Many Multisig And Pure Member 1']]
+    })
+
     cy.url().should('include', expectedMultiAddress)
     multisigPage.accountHeader().within(() => {
       accountDisplay.addressLabel().should('contain.text', expectedMultiAddress.slice(0, 6))

--- a/packages/ui/cypress/tests/landing-messaging.cy.ts
+++ b/packages/ui/cypress/tests/landing-messaging.cy.ts
@@ -23,10 +23,19 @@ describe('Landing Page Messaging', () => {
 
   it('can see an error when extension is connected but no account is shared', () => {
     cy.visit(landingPageUrl)
-    cy.initExtension([testAccounts['Multisig Member Account 1']])
+    cy.initExtension([])
     clickOnConnect()
-    // don't connect any of the initialized accounts
+    // Connect the extension but no account
     cy.connectAccounts([])
+    landingPage.shouldHaveNoAccountErrorAndWikiLink()
+  })
+
+  it('can see an error when landing with connected extension but no account shared', () => {
+    cy.visitWithLocalStorage({
+      url: landingPageUrl,
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: []
+    })
     landingPage.shouldHaveNoAccountErrorAndWikiLink()
   })
 
@@ -57,15 +66,14 @@ describe('Landing Page Messaging', () => {
   })
 
   it('can see an error when connected to an account and watched but not part of a multisig', () => {
-    const nonMemberPublicKey = testAccounts['Non Multisig Member 1'].publicKey!
+    const nonMemberPublicKey1 = testAccounts['Non Multisig Member 1'].publicKey!
     cy.visitWithLocalStorage({
       url: landingPageUrl,
-      watchedAccounts: [nonMemberPublicKey]
+      watchedAccounts: [nonMemberPublicKey1],
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [testAccounts['Non Multisig Member 2']]
     })
-    cy.initExtension([testAccounts['Non Multisig Member 1']])
-    clickOnConnect()
-    // connect another account that is not part of any multisig
-    cy.connectAccounts([testAccounts['Non Multisig Member 2'].address])
+
     landingPage
       .noMultisigFoundError()
       .should('contain.text', 'No multisig found for your accounts or watched accounts.')

--- a/packages/ui/cypress/tests/multisig-creation.cy.ts
+++ b/packages/ui/cypress/tests/multisig-creation.cy.ts
@@ -1,16 +1,17 @@
 import { landingPageNetwork } from '../fixtures/landingData'
 import { testAccounts } from '../fixtures/testAccounts'
 import { accountDisplay } from '../support/page-objects/components/accountDisplay'
-import { landingPage } from '../support/page-objects/landingPage'
 import { multisigPage } from '../support/page-objects/multisigPage'
 import { newMultisigPage } from '../support/page-objects/newMultisigPage'
 import { notifications } from '../support/page-objects/notifications'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
-import { clickOnConnect } from '../utils/clickOnConnect'
 
-const { address: address1 } = testAccounts['Funded Account 1 Chopsticks Kusama']
-const { address: address2 } = testAccounts['Funded Account 2 Chopsticks Kusama']
-const { address: address3 } = testAccounts['Funded Account 3 Chopsticks Kusama']
+const fundedAccount1 = testAccounts['Funded Account 1 Chopsticks Kusama']
+const fundedAccount2 = testAccounts['Funded Account 2 Chopsticks Kusama']
+const fundedAccount3 = testAccounts['Funded Account 3 Chopsticks Kusama']
+const { address: address1 } = fundedAccount1
+const { address: address2 } = fundedAccount2
+const { address: address3 } = fundedAccount3
 
 const typeAndAdd = (address: string) => {
   newMultisigPage.addressSelector().click().type(`${address}{downArrow}{enter}`)
@@ -18,10 +19,11 @@ const typeAndAdd = (address: string) => {
 }
 describe('Multisig creation', () => {
   beforeEach(() => {
-    cy.visit(landingPageNetwork('local'))
-    cy.initExtension(Object.values(testAccounts))
-    clickOnConnect()
-    cy.connectAccounts([address1, address2, address3])
+    cy.visitWithLocalStorage({
+      url: landingPageNetwork('local'),
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [fundedAccount1, fundedAccount2, fundedAccount3]
+    })
   })
 
   it('Create a multisig tx with proxy', () => {

--- a/packages/ui/cypress/tests/setIdentity.cy.ts
+++ b/packages/ui/cypress/tests/setIdentity.cy.ts
@@ -1,24 +1,19 @@
-import { InjectedAccountWitMnemonic } from '../fixtures/testAccounts'
 import { landingPageNetwork, landingPageUrl } from '../fixtures/landingData'
 import { setIdentityMultisigs } from '../fixtures/setIdentity/setIdentityMultisigs'
 import { setIdentitySignatories } from '../fixtures/setIdentity/setIdentitySignatories'
 import { multisigPage } from '../support/page-objects/multisigPage'
 import { sendTxModal } from '../support/page-objects/sendTxModal'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
-import { clickOnConnect } from '../utils/clickOnConnect'
 import { waitForTxRequest } from '../utils/waitForTxRequests'
-
-const initAndConnect = (account: InjectedAccountWitMnemonic, landingPage = landingPageUrl) => {
-  cy.visit(landingPage)
-  cy.initExtension([account])
-  clickOnConnect()
-  cy.connectAccounts([account.address])
-}
 
 describe('Set an identity', () => {
   it('Does not have the identity option if the pallet is not present', () => {
     const multisigSignatoryWithoutIdentity = setIdentitySignatories[3]
-    initAndConnect(multisigSignatoryWithoutIdentity, landingPageNetwork('joystream'))
+    cy.visitWithLocalStorage({
+      url: landingPageNetwork('joystream'),
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [multisigSignatoryWithoutIdentity]
+    })
     multisigPage.optionsMenuButton().click()
     multisigPage.setIdentityMenuOption().should('not.exist')
 
@@ -31,7 +26,11 @@ describe('Set an identity', () => {
 
   it('Can set an identity from the options menu', () => {
     const multisigSignatoryWithoutIdentity = setIdentitySignatories[1]
-    initAndConnect(multisigSignatoryWithoutIdentity)
+    cy.visitWithLocalStorage({
+      url: landingPageUrl,
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [multisigSignatoryWithoutIdentity]
+    })
     multisigPage.optionsMenuButton().click()
     multisigPage.setIdentityMenuOption().should('be.visible').click()
     sendTxModal.sendTxTitle().should('be.visible')
@@ -84,7 +83,11 @@ describe('Set an identity', () => {
 
   it('Can edit an identity from the new tx button', () => {
     const multisigSignatoryWithoutIdentity = setIdentitySignatories[0]
-    initAndConnect(multisigSignatoryWithoutIdentity)
+    cy.visitWithLocalStorage({
+      url: landingPageUrl,
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [multisigSignatoryWithoutIdentity]
+    })
     // select the right multisig (Alice has a lot)
     const first5DigitsAddress = setIdentityMultisigs['multisig-with-identity'].address.slice(0, 4)
     topMenuItems

--- a/packages/ui/cypress/tests/transactions.cy.ts
+++ b/packages/ui/cypress/tests/transactions.cy.ts
@@ -4,7 +4,6 @@ import { landingPageUrl } from '../fixtures/landingData'
 import { multisigPage } from '../support/page-objects/multisigPage'
 import { notifications } from '../support/page-objects/notifications'
 import { sendTxModal } from '../support/page-objects/sendTxModal'
-import { clickOnConnect } from '../utils/clickOnConnect'
 import { waitForTxRequest } from '../utils/waitForTxRequests'
 
 const testAccount1Address = testAccounts['Multisig Member Account 1'].address
@@ -17,10 +16,11 @@ const fillAndSubmitTransactionForm = () => {
 
 describe('Perform transactions', () => {
   beforeEach(() => {
-    cy.visit(landingPageUrl)
-    cy.initExtension(Object.values(testAccounts))
-    clickOnConnect()
-    cy.connectAccounts([testAccount1Address])
+    cy.visitWithLocalStorage({
+      url: landingPageUrl,
+      extensionConnectionAllowed: true,
+      injectedAccountsExtension: [testAccounts['Multisig Member Account 1']]
+    })
   })
 
   it('Abort a multisig tx', () => {

--- a/squid/assets/envs/.env edgeware
+++ b/squid/assets/envs/.env edgeware
@@ -1,0 +1,4 @@
+RPC_WS="wss://edgeware.jelliedowl.net"
+BLOCK_START=15000000
+PREFIX=7
+CHAIN_ID='edgeware'


### PR DESCRIPTION
closes #433

This allows to reduce a lot of the clicks to connect etc if not needed. Users once they've allowed a website to access their accounts will not have to authorize the connection every single time. This is what this feature enables.

The `visitWithLocalStorage` function which was used all over, now must have a new name. Please suggest anything better if you think `visitCustom` isn't great. The reason why I had to bloat it, is because the extension and the accounts need to be loaded in the window object before the page loads, which is also when we set the custom localStorage elements :man_shrugging: 