### PR TITLE
fix: menu jump during multisig switch

### DIFF
--- a/packages/ui/cypress/support/page-objects/topMenuItems.ts
+++ b/packages/ui/cypress/support/page-objects/topMenuItems.ts
@@ -9,7 +9,6 @@ export const topMenuItems = {
   multiproxySelector: () => cy.get('[data-cy=select-multiproxy]', { timeout: 20000 }),
   multiproxySelectorInput: () => cy.get('[data-cy=input-select-multiproxy]', { timeout: 10000 }),
   multiproxySelectorOption: () => cy.get('[data-cy=select-multiproxy-option]'),
-  multiproxyLoader: () => cy.get('[data-cy=proxy-selection-loader]', { timeout: 10000 }),
   networkSelector: () => cy.get('[data-cy=select-networks]'),
   networkSelectorOption: (networkName: string) =>
     cy.get(`[data-cy=select-network-option-${networkName}]`)

--- a/packages/ui/cypress/tests/network-switch.cy.ts
+++ b/packages/ui/cypress/tests/network-switch.cy.ts
@@ -35,9 +35,6 @@ describe('Network can be switched', () => {
     topMenuItems.desktopMenu().within(() => topMenuItems.multiproxySelector().should('exist'))
     topMenuItems.desktopMenu().within(() => topMenuItems.networkSelector().click())
     topMenuItems.networkSelectorOption('kusama').click()
-    topMenuItems
-      .desktopMenu()
-      .within(() => cy.waitUntil(() => topMenuItems.multiproxyLoader().should('not.be.visible')))
 
     cy.url().should('contain', 'network=kusama')
     cy.url().should('not.contain', 'address=')

--- a/packages/ui/cypress/utils/clickOnConnect.ts
+++ b/packages/ui/cypress/utils/clickOnConnect.ts
@@ -4,6 +4,6 @@ import { waitForAuthRequest } from './waitForAuthRequests'
 
 export const clickOnConnect = () => {
   topMenuItems.connectButton().click()
-  landingPage.accountsLoader().should('contain', 'Loading accounts')
+  landingPage.accountsLoader().should('contain', 'Loading your accounts')
   waitForAuthRequest()
 }

--- a/packages/ui/src/components/LoadingBox.tsx
+++ b/packages/ui/src/components/LoadingBox.tsx
@@ -3,11 +3,11 @@ import { Box, CircularProgress } from '@mui/material'
 
 interface Props {
   message: string
-  dataCy?: string
+  testId?: string
 }
 
-const LoadingBox = ({ message, dataCy }: Props) => (
-  <MessageBox data-cy={dataCy}>
+const LoadingBox = ({ message, testId }: Props) => (
+  <MessageBox data-cy={`loader-${testId}`}>
     <CircularProgress />
     <div>{message}</div>
   </MessageBox>

--- a/packages/ui/src/components/LoadingBox.tsx
+++ b/packages/ui/src/components/LoadingBox.tsx
@@ -1,0 +1,25 @@
+import { styled } from '@mui/material/styles'
+import { Box, CircularProgress } from '@mui/material'
+
+interface Props {
+  message: string
+  dataCy?: string
+}
+
+const LoadingBox = ({ message, dataCy }: Props) => (
+  <MessageBox data-cy={dataCy}>
+    <CircularProgress />
+    <div>{message}</div>
+  </MessageBox>
+)
+
+export const MessageBox = styled(Box)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  padding: 1rem;
+`
+
+export default LoadingBox

--- a/packages/ui/src/components/select/MultiProxySelection.tsx
+++ b/packages/ui/src/components/select/MultiProxySelection.tsx
@@ -1,4 +1,4 @@
-import { Box, CircularProgress, InputAdornment } from '@mui/material'
+import { Box, InputAdornment } from '@mui/material'
 import React, { useCallback, useMemo, useRef } from 'react'
 import { styled } from '@mui/material/styles'
 import { createFilterOptions } from '@mui/material/Autocomplete'
@@ -126,18 +126,7 @@ const MultiProxySelection = ({ className }: Props) => {
     />
   )
 
-  if (isLoading) {
-    return (
-      <BoxStyled>
-        <CircularProgress
-          data-cy="proxy-selection-loader"
-          size={24}
-        />
-      </BoxStyled>
-    )
-  }
-
-  if (multiProxyList.length === 0) {
+  if (isLoading || multiProxyList.length === 0) {
     return null
   }
 
@@ -157,14 +146,6 @@ const MultiProxySelection = ({ className }: Props) => {
     />
   )
 }
-
-const BoxStyled = styled(Box)`
-  display: flex;
-
-  .MuiCircularProgress-root {
-    color: ${({ theme }) => theme.palette.primary.main};
-  }
-`
 
 export default styled(MultiProxySelection)`
   min-width: 12.5rem;

--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -36,7 +36,7 @@ export interface IMultisigContext {
   selectedMultiProxy?: MultiProxy
   multiProxyList: MultiProxy[]
   isLoading: boolean
-  isFetching: boolean
+  isFetchingMultisigs: boolean
   selectMultiProxy: (multi: MultiProxy | string) => boolean
   selectedHasProxy: boolean
   error: Error | null
@@ -226,7 +226,7 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
   const watchedAddressesIds = useAccountId(watchedAddresses)
   const {
     isLoading: isMultisigsubLoading,
-    isFetching: isMultisigsFetching,
+    isFetchingMultisigs,
     error: isMultisigSubError,
     refetch: refetchMultisigSub
   } = useMultisigsBySignatoriesOrWatchedSubscription({
@@ -343,7 +343,7 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
         multiProxyList,
         selectMultiProxy,
         isLoading,
-        isFetching: isMultisigsFetching,
+        isFetchingMultisigs,
         selectedHasProxy,
         error: isMultisigSubError || isPureSubError,
         getMultisigByAddress,

--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -36,7 +36,6 @@ export interface IMultisigContext {
   selectedMultiProxy?: MultiProxy
   multiProxyList: MultiProxy[]
   isLoading: boolean
-  isFetchingMultisigs: boolean
   selectMultiProxy: (multi: MultiProxy | string) => boolean
   selectedHasProxy: boolean
   error: Error | null
@@ -226,7 +225,6 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
   const watchedAddressesIds = useAccountId(watchedAddresses)
   const {
     isLoading: isMultisigsubLoading,
-    isFetchingMultisigs,
     error: isMultisigSubError,
     refetch: refetchMultisigSub
   } = useMultisigsBySignatoriesOrWatchedSubscription({
@@ -343,7 +341,6 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
         multiProxyList,
         selectMultiProxy,
         isLoading,
-        isFetchingMultisigs,
         selectedHasProxy,
         error: isMultisigSubError || isPureSubError,
         getMultisigByAddress,

--- a/packages/ui/src/contexts/MultiProxyContext.tsx
+++ b/packages/ui/src/contexts/MultiProxyContext.tsx
@@ -36,6 +36,7 @@ export interface IMultisigContext {
   selectedMultiProxy?: MultiProxy
   multiProxyList: MultiProxy[]
   isLoading: boolean
+  isFetching: boolean
   selectMultiProxy: (multi: MultiProxy | string) => boolean
   selectedHasProxy: boolean
   error: Error | null
@@ -225,6 +226,7 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
   const watchedAddressesIds = useAccountId(watchedAddresses)
   const {
     isLoading: isMultisigsubLoading,
+    isFetching: isMultisigsFetching,
     error: isMultisigSubError,
     refetch: refetchMultisigSub
   } = useMultisigsBySignatoriesOrWatchedSubscription({
@@ -341,6 +343,7 @@ const MultiProxyContextProvider = ({ children }: MultisigContextProps) => {
         multiProxyList,
         selectMultiProxy,
         isLoading,
+        isFetching: isMultisigsFetching,
         selectedHasProxy,
         error: isMultisigSubError || isPureSubError,
         getMultisigByAddress,

--- a/packages/ui/src/hooks/useDisplayLoader.tsx
+++ b/packages/ui/src/hooks/useDisplayLoader.tsx
@@ -15,7 +15,7 @@ export const useDisplayLoader = () => {
   if (!isWatchAddressInitialized || !isLocalStorageSetupDone) {
     return (
       <LoadingBox
-        message={'Initialization...'}
+        message="Initialization..."
         dataCy="loader-initialization"
       />
     )

--- a/packages/ui/src/hooks/useDisplayLoader.tsx
+++ b/packages/ui/src/hooks/useDisplayLoader.tsx
@@ -1,10 +1,9 @@
-import { styled } from '@mui/material/styles'
 import { useMultiProxy } from '../contexts/MultiProxyContext'
 import { useApi } from '../contexts/ApiContext'
-import { Box, CircularProgress } from '@mui/material'
 import { useNetwork } from '../contexts/NetworkContext'
 import { useAccounts } from '../contexts/AccountsContext'
 import { useWatchedAddresses } from '../contexts/WatchedAddressesContext'
+import LoadingBox from '../components/LoadingBox'
 
 export const useDisplayLoader = () => {
   const { isLoading: isLoadingMultisigs } = useMultiProxy()
@@ -15,48 +14,39 @@ export const useDisplayLoader = () => {
 
   if (!isWatchAddressInitialized || !isLocalStorageSetupDone) {
     return (
-      <LoaderBoxStyled data-cy="loader-initialization">
-        <CircularProgress />
-        Initialization...
-      </LoaderBoxStyled>
+      <LoadingBox
+        message={'Initialization...'}
+        dataCy="loader-initialization"
+      />
     )
   }
 
   if (!api) {
     return (
-      <LoaderBoxStyled data-cy="loader-rpc-connection">
-        <CircularProgress />
-        {`Connecting to the node at ${selectedNetworkInfo?.rpcUrl}`}
-      </LoaderBoxStyled>
+      <LoadingBox
+        message={`Connecting to the node at ${selectedNetworkInfo?.rpcUrl}`}
+        dataCy="loader-rpc-connection"
+      />
     )
   }
 
   if (isAccountLoading) {
     return (
-      <LoaderBoxStyled data-cy="loader-accounts-connection">
-        <CircularProgress />
-        Loading accounts...
-      </LoaderBoxStyled>
+      <LoadingBox
+        message="Loading your accounts..."
+        dataCy="loader-accounts-connection"
+      />
     )
   }
 
   if (isLoadingMultisigs) {
     return (
-      <LoaderBoxStyled data-cy="loader-multisigs">
-        <CircularProgress />
-        <div>Loading your multisigs...</div>
-      </LoaderBoxStyled>
+      <LoadingBox
+        message="Loading your multisigs..."
+        dataCy="loader-multisigs"
+      />
     )
   }
 
   return null
 }
-
-const LoaderBoxStyled = styled(Box)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  width: 100%;
-  padding: 1rem;
-`

--- a/packages/ui/src/hooks/useDisplayLoader.tsx
+++ b/packages/ui/src/hooks/useDisplayLoader.tsx
@@ -16,7 +16,7 @@ export const useDisplayLoader = () => {
     return (
       <LoadingBox
         message="Initialization..."
-        dataCy="loader-initialization"
+        testId="initialization"
       />
     )
   }
@@ -25,7 +25,7 @@ export const useDisplayLoader = () => {
     return (
       <LoadingBox
         message={`Connecting to the node at ${selectedNetworkInfo?.rpcUrl}`}
-        dataCy="loader-rpc-connection"
+        testId="rpc-connection"
       />
     )
   }
@@ -34,7 +34,7 @@ export const useDisplayLoader = () => {
     return (
       <LoadingBox
         message="Loading your accounts..."
-        dataCy="loader-accounts-connection"
+        testId="accounts-connection"
       />
     )
   }
@@ -43,7 +43,7 @@ export const useDisplayLoader = () => {
     return (
       <LoadingBox
         message="Loading your multisigs..."
-        dataCy="loader-multisigs"
+        testId="multisigs"
       />
     )
   }

--- a/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
@@ -54,7 +54,7 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
     )
   }
 
-  const { error, data, isLoading, refetch, isFetching } = useSubscription(
+  const { error, data, isLoading, refetch } = useSubscription(
     [`KeyMultisigsBySignatoriesOrWatched-${accountIds}-${watchedAccountIds}-${selectedNetwork}`],
     () => {
       onUpdate(null)

--- a/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
@@ -109,7 +109,6 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
   return {
     data,
     isLoading: hasSomethingToQuery && isLoading,
-    isFetchingMultisigs: isFetching,
     error,
     refetch
   }

--- a/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
@@ -106,5 +106,11 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
   // console.log('subscription data', data)
   //   return <div>Data: {JSON.stringify(data?.multisigCalls)}</div>;
 
-  return { data, isLoading: hasSomethingToQuery && isLoading, isFetching, error, refetch }
+  return {
+    data,
+    isLoading: hasSomethingToQuery && isLoading,
+    isFetchingMultisigs: isFetching,
+    error,
+    refetch
+  }
 }

--- a/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
+++ b/packages/ui/src/hooks/useMultisigsBySignatoriesOrWatchedSubscription.tsx
@@ -54,7 +54,7 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
     )
   }
 
-  const { error, data, isLoading, refetch } = useSubscription(
+  const { error, data, isLoading, refetch, isFetching } = useSubscription(
     [`KeyMultisigsBySignatoriesOrWatched-${accountIds}-${watchedAccountIds}-${selectedNetwork}`],
     () => {
       onUpdate(null)
@@ -106,5 +106,5 @@ export const useMultisigsBySignatoriesOrWatchedSubscription = ({
   // console.log('subscription data', data)
   //   return <div>Data: {JSON.stringify(data?.multisigCalls)}</div>;
 
-  return { data, isLoading: hasSomethingToQuery && isLoading, error, refetch }
+  return { data, isLoading: hasSomethingToQuery && isLoading, isFetching, error, refetch }
 }

--- a/packages/ui/src/pages/Overview/index.tsx
+++ b/packages/ui/src/pages/Overview/index.tsx
@@ -37,14 +37,19 @@ const getMultisigInfo = (multisig: MultiProxy['multisigs'][0]) => {
 }
 
 const Overview = ({ className }: Props) => {
-  const { selectedMultiProxy, multiProxyList, isLoading: isLoadingMultisigs } = useMultiProxy()
+  const {
+    selectedMultiProxy,
+    multiProxyList,
+    isLoading: isLoadingMultisigs,
+    isFetching
+  } = useMultiProxy()
   const hasPureProxy = useMemo(() => selectedMultiProxy?.proxy, [selectedMultiProxy?.proxy])
   const hasSeveralMultisigs = useMemo(
     () => selectedMultiProxy?.multisigs && selectedMultiProxy?.multisigs.length > 1,
     [selectedMultiProxy]
   )
 
-  if (isLoadingMultisigs) {
+  if (isFetching) {
     return (
       <LoadingBox
         message="Loading your multisigs..."

--- a/packages/ui/src/pages/Overview/index.tsx
+++ b/packages/ui/src/pages/Overview/index.tsx
@@ -9,6 +9,8 @@ import 'reactflow/dist/style.css'
 import OverviewHeaderView from './OverviewHeaderView'
 import { renderMultisigHeading } from '../multisigHelpers'
 import { ConnectOrWatch } from '../../components/ConnectCreateOrWatch'
+import LoadingBox from '../../components/LoadingBox'
+
 interface Props {
   className?: string
 }
@@ -35,12 +37,21 @@ const getMultisigInfo = (multisig: MultiProxy['multisigs'][0]) => {
 }
 
 const Overview = ({ className }: Props) => {
-  const { selectedMultiProxy, multiProxyList } = useMultiProxy()
+  const { selectedMultiProxy, multiProxyList, isLoading: isLoadingMultisigs } = useMultiProxy()
   const hasPureProxy = useMemo(() => selectedMultiProxy?.proxy, [selectedMultiProxy?.proxy])
   const hasSeveralMultisigs = useMemo(
     () => selectedMultiProxy?.multisigs && selectedMultiProxy?.multisigs.length > 1,
     [selectedMultiProxy]
   )
+
+  if (isLoadingMultisigs) {
+    return (
+      <LoadingBox
+        message="Loading your multisigs..."
+        dataCy="loader-multisigs"
+      />
+    )
+  }
 
   if (multiProxyList.length === 0) {
     return <ConnectOrWatch />

--- a/packages/ui/src/pages/Overview/index.tsx
+++ b/packages/ui/src/pages/Overview/index.tsx
@@ -37,14 +37,14 @@ const getMultisigInfo = (multisig: MultiProxy['multisigs'][0]) => {
 }
 
 const Overview = ({ className }: Props) => {
-  const { selectedMultiProxy, multiProxyList, isFetchingMultisigs } = useMultiProxy()
+  const { selectedMultiProxy, multiProxyList, isLoading } = useMultiProxy()
   const hasPureProxy = useMemo(() => selectedMultiProxy?.proxy, [selectedMultiProxy?.proxy])
   const hasSeveralMultisigs = useMemo(
     () => selectedMultiProxy?.multisigs && selectedMultiProxy?.multisigs.length > 1,
     [selectedMultiProxy]
   )
 
-  if (isFetchingMultisigs) {
+  if (isLoading) {
     return (
       <LoadingBox
         message="Loading your multisigs..."

--- a/packages/ui/src/pages/Overview/index.tsx
+++ b/packages/ui/src/pages/Overview/index.tsx
@@ -48,7 +48,7 @@ const Overview = ({ className }: Props) => {
     return (
       <LoadingBox
         message="Loading your multisigs..."
-        dataCy="loader-multisigs"
+        testId="multisigs"
       />
     )
   }

--- a/packages/ui/src/pages/Overview/index.tsx
+++ b/packages/ui/src/pages/Overview/index.tsx
@@ -37,19 +37,14 @@ const getMultisigInfo = (multisig: MultiProxy['multisigs'][0]) => {
 }
 
 const Overview = ({ className }: Props) => {
-  const {
-    selectedMultiProxy,
-    multiProxyList,
-    isLoading: isLoadingMultisigs,
-    isFetching
-  } = useMultiProxy()
+  const { selectedMultiProxy, multiProxyList, isFetchingMultisigs } = useMultiProxy()
   const hasPureProxy = useMemo(() => selectedMultiProxy?.proxy, [selectedMultiProxy?.proxy])
   const hasSeveralMultisigs = useMemo(
     () => selectedMultiProxy?.multisigs && selectedMultiProxy?.multisigs.length > 1,
     [selectedMultiProxy]
   )
 
-  if (isFetching) {
+  if (isFetchingMultisigs) {
     return (
       <LoadingBox
         message="Loading your multisigs..."


### PR DESCRIPTION
closes #387

- Fixes UI jump during multisig switch 
- The loader is not shown anymore for the multiproxy selector
- Overview page has loading status during multisigs fetching

---

Submission checklist:

#### Layout

- [X] Change inspected in the desktop webUIi
- [X] Change inspected in the mobile webUIi

#### Compatibility

- [X] Functionality of change validated with a connected account with multisig
- [ ] Applicable elements hidden/disabled for watched multisigs / pure
- [X] Looks good for solo multisig
- [X] Looks good for multisig with proxy
