### PR TITLE
Change RPC URLs - Polkadot and Kusama

### DIFF
--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -39,7 +39,7 @@ export const networkList = {
   polkadot: {
     chainId: 'polkadot',
     explorerNetworkName: 'polkadot',
-    rpcUrl: 'wss://rpc.polkadot.io',
+    rpcUrl: 'wss://polkadot.api.onfinality.io',
     wsGraphqlUrl: 'wss://squid.subsquid.io/multix-arrow/v/v2/graphql',
     httpGraphqlUrl: 'https://squid.subsquid.io/multix-arrow/v/v2/graphql',
     logo: chainsPolkadotCircleSVG
@@ -47,7 +47,7 @@ export const networkList = {
   kusama: {
     chainId: 'kusama',
     explorerNetworkName: 'kusama',
-    rpcUrl: 'wss://kusama-rpc.polkadot.io',
+    rpcUrl: 'wss://kusama.api.onfinality.io',
     wsGraphqlUrl: 'wss://squid.subsquid.io/multix-arrow/v/v2/graphql',
     httpGraphqlUrl: 'https://squid.subsquid.io/multix-arrow/v/v2/graphql',
     logo: chainsKusamaSVG


### PR DESCRIPTION
rpc.polkadot.io and kusama-rpc.polkadot.io should not be used by or linked to within any dapps, as we cannot guarantee response times or service level. Ref: https://forum.polkadot.network/t/scaling-down-of-parity-s-public-infrastructure/4697

Adding an alternate URL. Feel free to modify.

closes #

---

Submission checklist:

#### Layout

- [ ] Change inspected in the desktop web ui
- [ ] Change inspected in the mobile web ui

#### Compatibility

- [ ] Functionality of change validated with a connected account with multisig
- [ ] Applicable elements hidden / disabled for watched multisigs / pure
- [ ] Looks good for solo multisig
- [ ] Looks good for multisig with proxy
