### PR TITLE
Show watch indicator

### DIFF
--- a/packages/ui/cypress/support/page-objects/components/accountDisplay.ts
+++ b/packages/ui/cypress/support/page-objects/components/accountDisplay.ts
@@ -3,5 +3,6 @@ export const accountDisplay = {
   pureBadge: () => cy.get('[data-cy=badge-pure]'),
   multisigBadge: () => cy.get('[data-cy=badge-multi]'),
   nameLabel: () => cy.get('[data-cy=label-account-name]'),
-  addressLabel: () => cy.get('[data-cy=label-account-address]')
+  addressLabel: () => cy.get('[data-cy=label-account-address]'),
+  watchedIcon: () => cy.get('[data-cy=icon-watched]')
 }

--- a/packages/ui/cypress/tests/multisig-creation.cy.ts
+++ b/packages/ui/cypress/tests/multisig-creation.cy.ts
@@ -164,6 +164,7 @@ describe('Multisig creation', () => {
       multisigPage.accountHeader(10000).within(() => {
         accountDisplay.addressLabel().should('contain.text', expectedMultisigAddressFirst6Char)
         accountDisplay.nameLabel().should('contain.text', multisigName)
+        accountDisplay.watchedIcon().should('not.exist')
       })
 
       verifySignatories()

--- a/packages/ui/cypress/tests/walletconnect.cy.ts
+++ b/packages/ui/cypress/tests/walletconnect.cy.ts
@@ -3,7 +3,7 @@ import { settingsPage } from '../support/page-objects/settingsPage'
 import { topMenuItems } from '../support/page-objects/topMenuItems'
 import { testAccounts } from '../fixtures/testAccounts'
 
-describe('Wallet Connect', () => {
+describe('WalletConnect', () => {
   it('can see expected wc state when a wallet is not connected', () => {
     cy.visit(settingsPageUrl)
     topMenuItems.connectButton().should('be.visible')

--- a/packages/ui/cypress/tests/watched-accounts.cy.ts
+++ b/packages/ui/cypress/tests/watched-accounts.cy.ts
@@ -93,6 +93,7 @@ describe('Watched Accounts', () => {
     topMenuItems.multiproxySelectorOptionDesktop().within(() => {
       accountDisplay.identicon().should('be.visible')
       accountDisplay.multisigBadge().should('be.visible')
+      accountDisplay.watchedIcon().should('be.visible')
       accountDisplay.pureBadge().should('not.exist')
       accountDisplay.nameLabel().should('have.text', multisigName)
     })
@@ -101,6 +102,7 @@ describe('Watched Accounts', () => {
     multisigPage.accountHeader().within(() => {
       accountDisplay.identicon().should('be.visible')
       accountDisplay.multisigBadge().should('be.visible')
+      accountDisplay.watchedIcon().should('be.visible')
       accountDisplay.pureBadge().should('not.exist')
       accountDisplay.nameLabel().should('have.text', multisigName)
     })
@@ -126,6 +128,7 @@ describe('Watched Accounts', () => {
     topMenuItems.multiproxySelectorOptionDesktop().within(() => {
       accountDisplay.identicon().should('be.visible')
       accountDisplay.pureBadge().should('be.visible')
+      accountDisplay.watchedIcon().should('be.visible')
       accountDisplay.multisigBadge().should('not.exist')
       accountDisplay.nameLabel().should('have.text', pureName)
     })
@@ -134,6 +137,7 @@ describe('Watched Accounts', () => {
     multisigPage.accountHeader().within(() => {
       accountDisplay.identicon().should('be.visible')
       accountDisplay.pureBadge().should('be.visible')
+      accountDisplay.watchedIcon().should('be.visible')
       accountDisplay.multisigBadge().should('not.exist')
       accountDisplay.nameLabel().should('have.text', pureName)
     })
@@ -257,6 +261,7 @@ describe('Watched Accounts', () => {
             .addressLabel()
             .should('be.visible')
             .and('contain.text', pureAddress.slice(0, 6))
+          accountDisplay.watchedIcon().should('be.visible')
         })
       multisigPage.multisigDetailsContainer().within(() => {
         multisigPage.multisigAccountSummary().within(() => {
@@ -264,6 +269,7 @@ describe('Watched Accounts', () => {
             .addressLabel()
             .should('be.visible')
             .and('contain.text', multisigAddress.slice(0, 6))
+          accountDisplay.watchedIcon().should('be.visible')
         })
       })
       topMenuItems.multiproxySelectorDesktop().should('be.visible').click()
@@ -272,6 +278,7 @@ describe('Watched Accounts', () => {
         .should('have.length', 1)
         .within(() => {
           accountDisplay.pureBadge().should('be.visible')
+          accountDisplay.watchedIcon().should('be.visible')
           accountDisplay
             .addressLabel()
             .should('be.visible')
@@ -318,6 +325,7 @@ describe('Watched Accounts', () => {
       .each(($el, index) => {
         cy.wrap($el).within(() => {
           accountDisplay.addressLabel().should('contain.text', expectedAddresses[index].slice(0, 6))
+          accountDisplay.watchedIcon().should('be.visible')
           if (index < 3) {
             accountDisplay.pureBadge().should('exist')
           } else {
@@ -334,6 +342,7 @@ describe('Watched Accounts', () => {
         .should('be.visible')
         .within(() => {
           accountDisplay.addressLabel().should('contain.text', address.slice(0, 6))
+          accountDisplay.watchedIcon().should('be.visible')
         })
     })
   })

--- a/packages/ui/src/components/IdenticonBadge.tsx
+++ b/packages/ui/src/components/IdenticonBadge.tsx
@@ -48,7 +48,7 @@ export const IdenticonBadge = ({
       color="primary"
       badgeContent={
         <>
-          {isWatchedAccount(address) ? <EyeIconStyled /> : null}
+          {isWatchedAccount(address) ? <EyeIconStyled data-cy="icon-watched" /> : null}
           {badge}
         </>
       }

--- a/packages/ui/src/components/IdenticonBadge.tsx
+++ b/packages/ui/src/components/IdenticonBadge.tsx
@@ -4,6 +4,8 @@ import { styled } from '@mui/material/styles'
 import { AccountBadge, IconSizeVariant } from '../types'
 import MultixIdenticon from './MultixIdenticon'
 import { ICON_SIZE_LARGE, ICON_SIZE_MEDIUM, ICON_SIZE_SMALL } from '../constants'
+import { HiMiniEye as EyeIcon } from 'react-icons/hi2'
+import { useMultiProxy } from '../contexts/MultiProxyContext'
 
 interface Props {
   className?: string
@@ -20,6 +22,8 @@ export const IdenticonBadge = ({
   sideBadge = false,
   size = 'medium'
 }: Props) => {
+  const { isWatchedAccount } = useMultiProxy()
+
   const AccountIcon = () => (
     <MultixIdenticon
       value={address}
@@ -42,7 +46,12 @@ export const IdenticonBadge = ({
       slotProps={{ badgeType: badge, sideBadge }}
       size={size}
       color="primary"
-      badgeContent={badge}
+      badgeContent={
+        <>
+          {isWatchedAccount(address) ? <EyeIconStyled /> : null}
+          {badge}
+        </>
+      }
       anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
       data-cy={`badge-${badge}`}
     >
@@ -50,6 +59,10 @@ export const IdenticonBadge = ({
     </BadgeStyled>
   )
 }
+
+const EyeIconStyled = styled(EyeIcon)`
+  margin-right: 0.2rem;
+`
 
 const BadgeStyled = styled(Badge)<{
   size: IconSizeVariant
@@ -68,7 +81,7 @@ const BadgeStyled = styled(Badge)<{
     `}
 
   .MuiBadge-badge {
-    max-width: 3.285rem;
+    max-width: 5.3rem;
     max-height: 1.69rem;
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;
@@ -77,6 +90,7 @@ const BadgeStyled = styled(Badge)<{
     border-radius: ${({ theme }) => theme.custom.borderRadius};
     border: 1px solid ${({ theme }) => theme.custom.gray[400]};
     transform: scale(1) translate(-20%, 0);
+    flex-wrap: nowrap;
 
     ${({ theme, slotProps: { badgeType } }) =>
       badgeType === AccountBadge.PURE &&


### PR DESCRIPTION
closes #176 

Not 100% convinced as this kinds of hides a good part of the identicon.. but on the other hand, we're talking about watched accounts.. so it's not that important.

![image](https://github.com/ChainSafe/Multix/assets/33178835/8e5fe0f8-c6cd-4e3e-98a5-ebb779b0e931)
![image](https://github.com/ChainSafe/Multix/assets/33178835/dc026dda-3867-4256-b900-5d3a88ae13d2)

---

Submission checklist:

#### Layout

- [x] Change inspected in the desktop web ui
- [x] Change inspected in the mobile web ui

#### Compatibility

- [x] Functionality of change validated with a connected account with multisig
- [x] Looks good for solo multisig
- [x] Looks good for multisig with proxy
