### PR TITLE
Fix identity test

### DIFF
--- a/chopsticks-config.yml
+++ b/chopsticks-config.yml
@@ -1,4 +1,4 @@
-endpoint: wss://rpc.ibp.network/kusama
+endpoint: wss://rpc-kusama.luckyfriday.io
 mock-signature-host: true
 block: 20487320
 db: ./db.sqlite

--- a/packages/ui/cypress/fixtures/setIdentity/setIdentityMultisigs.ts
+++ b/packages/ui/cypress/fixtures/setIdentity/setIdentityMultisigs.ts
@@ -10,10 +10,10 @@ export const setIdentityMultisigs = {
 
   // this is a multisig I use all the time. Because Rococo now filters identity calls
   // I couldn't re-create a dedicated one so only sharing here 1 signatory
-  'multisig-with-identity': {
+  'pure-with-polkadot-identity': {
     name: 'Multisig with identity',
-    address: '5EMm18Z8WWWT2wit1RxpoZv39goPdYmSksnDTePYAzrUhdJv',
+    address: '15KHTWdJyzyxaQbBNRmQN89KmFr1jPXXsPHM5Rxvd1Tkb2XZ',
     threshold: 2,
-    signatories: [setIdentitySignatories[0].address]
+    signatories: [setIdentitySignatories[4]]
   }
 }

--- a/packages/ui/cypress/fixtures/setIdentity/setIdentitySignatories.ts
+++ b/packages/ui/cypress/fixtures/setIdentity/setIdentitySignatories.ts
@@ -29,5 +29,13 @@ export const setIdentitySignatories = [
     name: 'Real account with Multisig',
     type: 'sr25519',
     mnemonic: ''
+  },
+  {
+    // this is a polkadot account, with multisig, but not one of our accounts, we don't actually know the mnemonic,
+    // so we can't sign anything with it
+    address: '12WWjrZGuVxyk5AyFeDGaN45J1FJ6MesXRxhmY41rhKxL961',
+    name: 'Real account with Multisig 2',
+    type: 'sr25519',
+    mnemonic: ''
   }
 ] as InjectedAccountWitMnemonic[]

--- a/packages/ui/cypress/tests/setIdentity.cy.ts
+++ b/packages/ui/cypress/tests/setIdentity.cy.ts
@@ -82,14 +82,16 @@ describe('Set an identity', () => {
   })
 
   it('Can edit an identity from the new tx button', () => {
-    const multisigSignatoryWithoutIdentity = setIdentitySignatories[0]
     cy.setupAndVisit({
-      url: landingPageUrl,
+      url: landingPageNetwork('polkadot'),
       extensionConnectionAllowed: true,
-      injectExtensionWithAccounts: [multisigSignatoryWithoutIdentity]
+      injectExtensionWithAccounts: setIdentityMultisigs['pure-with-polkadot-identity'].signatories
     })
     // select the right multisig (Alice has a lot)
-    const first5DigitsAddress = setIdentityMultisigs['multisig-with-identity'].address.slice(0, 4)
+    const first5DigitsAddress = setIdentityMultisigs['pure-with-polkadot-identity'].address.slice(
+      0,
+      4
+    )
     topMenuItems
       .desktopMenu()
       .within(() =>
@@ -105,15 +107,15 @@ describe('Set an identity', () => {
     sendTxModal.selectionEasySetupSetIdentity().click()
 
     const expectedIdentity = {
-      display: 'Some new name',
-      legal: 'legaly idk',
-      web: 'http://www.test.com'
+      display: 'The Kus DOT Delegate',
+      twitter: '@TheKusamarian',
+      email: 'hey@thekusamarian.xyz'
     }
 
     // Some fields should be pre-filled
     sendTxModal.setIdentityFieldInput('display').should('have.value', expectedIdentity.display)
-    sendTxModal.setIdentityFieldInput('legal').should('have.value', expectedIdentity.legal)
-    sendTxModal.setIdentityFieldInput('web').should('have.value', expectedIdentity.web)
+    sendTxModal.setIdentityFieldInput('email').should('have.value', expectedIdentity.email)
+    sendTxModal.setIdentityFieldInput('twitter').should('have.value', expectedIdentity.twitter)
 
     // Remove the Display and we should have an error
     sendTxModal.setIdentityField('display').type('{selectall}{del}')


### PR DESCRIPTION
Rococo removed the identity pallet. We now do the test on Polkadot, that still has it.