### PR TITLE
Fix erroneous error in Manual Extrinsic

### DIFF
--- a/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
+++ b/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
@@ -301,7 +301,6 @@ const ManualExtrinsic = ({
     }
 
     if (api.tx[palletRpc][callable].meta.args.length !== transformedParams?.length) {
-      onSetErrorMessage('Unexpected number of params.')
       return
     }
 

--- a/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
+++ b/packages/ui/src/components/EasySetup/ManualExtrinsic.tsx
@@ -181,7 +181,7 @@ const ManualExtrinsic = ({
         return [...previousValue, value]
       }, [] as any[])
     },
-    [chainInfo, isAmountOverflow, isValidAmountString]
+    [callable, chainInfo?.tokenDecimals, isAmountOverflow, isValidAmountString, palletRpc]
   )
 
   useEffect(() => {
@@ -297,6 +297,11 @@ const ManualExtrinsic = ({
     }
 
     if (!callable || !palletRpc || !areAllParamsFilled || hasErrorMessage) {
+      return
+    }
+
+    if (api.tx[palletRpc][callable].meta.args.length !== transformedParams?.length) {
+      onSetErrorMessage('Unexpected number of params.')
       return
     }
 


### PR DESCRIPTION
When there's only 1 param in the extrinsic, e.g beefy.setNewGenesis. If you type 1 number for instance (valid) you'll still get a meaningless error.

This has other repercussions, so that if you do on Polkadot `staking.bondExtra` the number of DOT won't be multiplied by  10^decimals :roll_eyes: 

![image](https://github.com/ChainSafe/Multix/assets/33178835/7f3a2807-e1fa-45f8-a90f-de1d71cfa6f9)
