### PR TITLE
Hotfix for WalletConnect connection

### DIFF
--- a/packages/ui/src/components/WalletConnect/WalletConnectActiveSessions.tsx
+++ b/packages/ui/src/components/WalletConnect/WalletConnectActiveSessions.tsx
@@ -43,6 +43,7 @@ export const WalletConnectActiveSessions = () => {
               <ul>
                 <li>Namespace: {session.requiredNamespaces?.polkadot?.chains?.join(', ')}</li>
                 <li>Methods: {session.requiredNamespaces?.polkadot?.methods?.join(', ')}</li>
+                <li>Events: {session.requiredNamespaces?.polkadot?.events?.join(', ')}</li>
                 <li>Expiring: {expiryDate.toDateString()}</li>
               </ul>
             </div>

--- a/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
+++ b/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
@@ -30,10 +30,20 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
     return getAccountsWithNamespace(accountsToShare)
   }, [getAccountsWithNamespace, selectedMultiProxy?.multisigs, selectedMultiProxy?.proxy])
 
+  const { methods, events, chains } = useMemo(
+    () =>
+      sessionProposal?.params.requiredNamespaces?.polkadot || {
+        methods: [],
+        events: [],
+        chains: []
+      },
+    [sessionProposal?.params.requiredNamespaces?.polkadot]
+  )
+
   useEffect(() => {
     if (!web3wallet || !sessionProposal) return
 
-    const wCRequestedNetwork = sessionProposal?.params.requiredNamespaces?.polkadot?.chains?.[0]
+    const wCRequestedNetwork = chains?.[0]
 
     if (wCRequestedNetwork !== currentNamespace) {
       setErrorMessage(
@@ -42,7 +52,7 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
         - Current: ${currentNamespace}`
       )
     }
-  }, [currentNamespace, sessionProposal, web3wallet])
+  }, [chains, currentNamespace, sessionProposal, web3wallet])
 
   const onApprove = useCallback(() => {
     if (!web3wallet || !sessionProposal) return
@@ -53,8 +63,8 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
         namespaces: {
           polkadot: {
             accounts: accountsToShare,
-            methods: sessionProposal.params.requiredNamespaces?.polkadot?.methods,
-            events: []
+            methods,
+            events
           }
         }
       })
@@ -63,7 +73,7 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
         onClose()
         refresh()
       })
-  }, [accountsToShare, onClose, refresh, sessionProposal, web3wallet])
+  }, [accountsToShare, events, methods, onClose, refresh, sessionProposal, web3wallet])
 
   const onReject = useCallback(() => {
     if (!web3wallet || !sessionProposal) return
@@ -99,16 +109,9 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
             <br />
             <AppInfoStyled>Website:</AppInfoStyled> {sessionProposal?.params.proposer.metadata.url}
             <br />
-            <AppInfoStyled>Methods:</AppInfoStyled>{' '}
-            {sessionProposal?.params.requiredNamespaces?.polkadot?.methods?.map(
-              (method, index) =>
-                `${method}${
-                  index ===
-                  (sessionProposal?.params.requiredNamespaces?.polkadot?.methods?.length - 1 || 0)
-                    ? ''
-                    : ', '
-                }`
-            )}
+            <AppInfoStyled>Methods:</AppInfoStyled> {methods.join(', ')}
+            <br />
+            <AppInfoStyled>Events:</AppInfoStyled> {events.join(', ')}
           </Grid>
           <Grid
             item

--- a/packages/ui/src/hooks/useWalletConnectEventsManager.ts
+++ b/packages/ui/src/hooks/useWalletConnectEventsManager.ts
@@ -14,6 +14,7 @@ export default function useWalletConnectEventsManager() {
   // Open session proposal modal for confirmation / rejection
   const onSessionProposal = useCallback(
     (proposal: SignClientTypes.EventArguments['session_proposal']) => {
+      console.info('WalletConnect session_proposal', proposal)
       openWalletConnectSessionModal({ sessionProposal: proposal })
     },
     [openWalletConnectSessionModal]
@@ -30,7 +31,7 @@ export default function useWalletConnectEventsManager() {
         console.error('web3Wallet is undefined')
         return
       }
-      console.log('---> session_request', requestEvent)
+      console.info('WalletConnect session_request', requestEvent)
       const { topic, params } = requestEvent
       const { request } = params
       const requestSession = web3wallet.engine.signClient.session.get(topic)


### PR DESCRIPTION
Although the events aren't formerly supported (account change and disconnect, to be supported in another PR see https://github.com/ChainSafe/Multix/issues/483) this will make sure that the connection is actually working and doesn't crash.

I updated [the wiki](https://github.com/ChainSafe/Multix/wiki/Connect-Dapps-to-Multix-using-WalletConnect-v2) with up to date images.