### PR TITLE
Fix: dollar typo

### DIFF
--- a/packages/ui/src/utils/getErrorMessageReservedFunds.tsx
+++ b/packages/ui/src/utils/getErrorMessageReservedFunds.tsx
@@ -21,7 +21,7 @@ const ReservedMessage = ({ reservedAmount }: { reservedAmount?: string }) => {
 
   return (
     <span>
-      Note that it includes ${reservedAmount} that will be reserved.{' '}
+      Note that it includes {reservedAmount} that will be reserved.{' '}
       <a
         href={wikiLinkReservedFunds}
         target="_blank"


### PR DESCRIPTION
We were showing a $ sign in front of an amount of DOT.