### PR TITLE
Enable copy address on click

### DIFF
--- a/packages/ui/src/components/AccountDisplay/AccountDisplay.tsx
+++ b/packages/ui/src/components/AccountDisplay/AccountDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material'
+import { Box, Tooltip } from '@mui/material'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { styled } from '@mui/material/styles'
 import { useAccountNames } from '../../contexts/AccountNamesContext'
@@ -11,9 +11,17 @@ import Balance from '../library/Balance'
 import { useGetEncodedAddress } from '../../hooks/useGetEncodedAddress'
 import { useIdentity } from '../../hooks/useIdentity'
 import { IconButton } from '@mui/material'
-import { HiOutlinePencilSquare as PencilIcon } from 'react-icons/hi2'
+import {
+  HiOutlinePencilSquare as PencilIcon,
+  HiOutlineSquare2Stack as CopyIcon
+} from 'react-icons/hi2'
 import { EditInput } from './EditInput'
 import { useAccounts } from '../../contexts/AccountsContext'
+import { copyTextToClipboard } from '../../utils/copyToClipboard'
+
+const DEFAULT_PLACEMENT = 'top'
+const DEFAULT_TITLE = 'Address copied!'
+const DEFAULT_AUTO_HIDE_DURATION = 2000
 
 interface Props {
   address: string
@@ -23,6 +31,7 @@ interface Props {
   withBalance?: boolean
   iconSize?: IconSizeVariant
   canEdit?: boolean
+  canCopy?: boolean
 }
 
 const AccountDisplay = ({
@@ -32,8 +41,10 @@ const AccountDisplay = ({
   withName = true,
   withBalance = false,
   iconSize = 'medium',
-  canEdit = false
+  canEdit = false,
+  canCopy = false
 }: Props) => {
+  const [isCopyTooltipOpen, setIsCopyTooltipOpen] = useState(false)
   const { getNamesWithExtension } = useAccountNames()
   const { ownAddressList } = useAccounts()
   const localName = useMemo(() => getNamesWithExtension(address), [address, getNamesWithExtension])
@@ -62,6 +73,14 @@ const AccountDisplay = ({
       setIdentityName(identity.displayParent || identity.display || '')
     }
   }, [address, api, identity])
+
+  const handleTooltipClose = useCallback(() => setIsCopyTooltipOpen(false), [])
+  const handleCopyAddress = useCallback(() => {
+    if (!canCopy) return
+
+    setIsCopyTooltipOpen(true)
+    copyTextToClipboard(address)
+  }, [address, canCopy])
 
   const onEditClick = useCallback(() => setIsEditing(true), [])
   const onCloseEdit = useCallback(() => setIsEditing(false), [])
@@ -118,10 +137,23 @@ const AccountDisplay = ({
           </>
         )}
         <AddressStyled
-          className="multisigAddress"
           data-cy="label-account-address"
+          onClick={handleCopyAddress}
         >
-          {getDisplayAddress(encodedAddress)}
+          <Tooltip
+            onClose={handleTooltipClose}
+            open={isCopyTooltipOpen}
+            title={DEFAULT_TITLE}
+            placement={DEFAULT_PLACEMENT}
+            leaveDelay={DEFAULT_AUTO_HIDE_DURATION}
+          >
+            <AddressWrapperStyled>{getDisplayAddress(encodedAddress)}</AddressWrapperStyled>
+          </Tooltip>
+          {canCopy && (
+            <CopyIconWrapperStyled className="copyIcon">
+              <CopyIcon />
+            </CopyIconWrapperStyled>
+          )}
         </AddressStyled>
         {withBalance && (
           <Box>
@@ -132,6 +164,24 @@ const AccountDisplay = ({
     </div>
   )
 }
+
+const AddressWrapperStyled = styled('span')``
+
+const CopyIconWrapperStyled = styled(Box)`
+  position: absolute;
+  top: 0;
+  width: 100%;
+  background: ${({ theme }) => theme.custom.gray[400]};
+  border-radius: 0.5rem;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  display: none;
+  opacity: 90%;
+  color: ${({ theme }) => theme.custom.gray[800]};
+`
 
 const EditIconButtonStyled = styled(IconButton)`
   color: ${({ theme }) => theme.custom.gray[700]};
@@ -185,9 +235,14 @@ const NameWrapperStyled = styled('div')`
 `
 
 const AddressStyled = styled('div')`
-  color: ${({ theme }) => theme.custom.text.primary};
+  color: ${({ theme }) => theme.custom.text.secondary};
   font-size: 1rem;
   font-weight: 400;
+  position: relative;
+
+  &:hover > .copyIcon {
+    display: flex;
+  }
 `
 
 const NameStyled = styled('div')`

--- a/packages/ui/src/components/DeepTxAlert.tsx
+++ b/packages/ui/src/components/DeepTxAlert.tsx
@@ -249,6 +249,7 @@ export const DeepTxAlert = ({ pendingTxCallData }: Props) => {
               <AccountDisplay
                 address={data1.from}
                 iconSize="small"
+                canCopy
               />
             </Grid>
           </Grid>

--- a/packages/ui/src/components/MultisigCompactDisplay.tsx
+++ b/packages/ui/src/components/MultisigCompactDisplay.tsx
@@ -43,6 +43,7 @@ const MultisigCompactDisplay = ({ className, address, expanded = false }: Props)
         isMultisig={signatories.length > 0}
         address={address}
         badge={badge}
+        canCopy
       />
       {signatories.length > 0 && (
         <Expander
@@ -60,7 +61,10 @@ const MultisigCompactDisplay = ({ className, address, expanded = false }: Props)
             <ul className="signatoryList">
               {signatories.map((sig) => (
                 <li key={sig}>
-                  <AccountDisplay address={sig} />
+                  <AccountDisplay
+                    address={sig}
+                    canCopy
+                  />
                 </li>
               ))}
             </ul>

--- a/packages/ui/src/components/Transactions/TransactionProgress.tsx
+++ b/packages/ui/src/components/Transactions/TransactionProgress.tsx
@@ -37,7 +37,10 @@ const ListItemToSign = ({ approvals, signer }: { approvals: string[]; signer: st
             <MdOutlineHourglassBottom size={24} />
           )}
         </ListItemIcon>
-        <AccountDisplay address={signer} />
+        <AccountDisplay
+          address={signer}
+          canCopy
+        />
       </ListItemButtonStyled>
     </ListItem>
   )

--- a/packages/ui/src/components/modals/ChangeMultisig.tsx
+++ b/packages/ui/src/components/modals/ChangeMultisig.tsx
@@ -374,6 +374,7 @@ const ChangeMultisig = ({ onClose, className }: Props) => {
                   <AccountDisplay
                     address={selectedMultiProxy?.proxy || ''}
                     badge={AccountBadge.PURE}
+                    canCopy
                   />
                 </Box>
                 {multisigList.length > 1 && (

--- a/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
+++ b/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
@@ -124,6 +124,7 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
                   address={selectedMultiProxy?.proxy}
                   badge={AccountBadge.PURE}
                   withName
+                  canCopy
                 />
               )}
               {selectedMultiProxy?.multisigs.map(({ address }) => {
@@ -133,6 +134,7 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
                     address={address}
                     badge={AccountBadge.MULTI}
                     withName
+                    canCopy
                   />
                 )
               })}

--- a/packages/ui/src/pages/Creation/Summary.tsx
+++ b/packages/ui/src/pages/Creation/Summary.tsx
@@ -93,6 +93,7 @@ const Summary = ({
           <AccountDisplayProxyStyled
             address={proxyAddress || ''}
             badge={AccountBadge.PURE}
+            canCopy
           />
         </>
       )}
@@ -114,6 +115,7 @@ const Summary = ({
             key={signatory}
             address={signatory}
             className="account"
+            canCopy
           />
         ))}
       </Paper>

--- a/packages/ui/src/pages/Home/HeaderView.tsx
+++ b/packages/ui/src/pages/Home/HeaderView.tsx
@@ -42,6 +42,7 @@ const HeaderView = () => {
           address={selectedAddress}
           badge={selectedHasProxy ? AccountBadge.PURE : AccountBadge.MULTI}
           canEdit
+          canCopy
         />
         <BalanceStyledWrapper>
           <BalanceStyled>
@@ -144,10 +145,6 @@ const AccountDisplayStyled = styled(AccountDisplay)`
     font-size: 1.5rem;
     font-weight: 500;
     color: ${({ theme }) => theme.custom.gray[800]};
-  }
-
-  .multisigAddress {
-    color: ${({ theme }) => theme.custom.text.secondary};
   }
 
   & > div:last-child {

--- a/packages/ui/src/pages/Home/MultisigAccordion.tsx
+++ b/packages/ui/src/pages/Home/MultisigAccordion.tsx
@@ -37,6 +37,7 @@ const MultisigAccordion = ({ multisig }: AccordionProps) => {
                 <AccountDisplay
                   address={signatory}
                   canEdit
+                  canCopy
                 />
               </li>
             ))}

--- a/packages/ui/src/pages/Home/MultisigView.tsx
+++ b/packages/ui/src/pages/Home/MultisigView.tsx
@@ -40,6 +40,7 @@ const MultisigView = () => {
                       badge={AccountBadge.MULTI}
                       withBalance={false}
                       canEdit
+                      canCopy
                     />
                   </AccountDisplayWrapperStyled>
                 )}

--- a/packages/ui/src/pages/Overview/CustomNode.tsx
+++ b/packages/ui/src/pages/Overview/CustomNode.tsx
@@ -37,6 +37,7 @@ const CustomNode = ({ data, className = '' }: Props) => {
       <AccountDisplay
         address={address}
         badge={badge}
+        canCopy
       />
     </Box>
   )

--- a/packages/ui/src/pages/Overview/index.tsx
+++ b/packages/ui/src/pages/Overview/index.tsx
@@ -71,6 +71,7 @@ const Overview = ({ className }: Props) => {
               address={selectedMultiProxy?.proxy || ''}
               badge={AccountBadge.PURE}
               withName
+              canCopy
             />
             <div>
               <div>
@@ -88,6 +89,7 @@ const Overview = ({ className }: Props) => {
                       <AccountDisplay
                         address={address}
                         badge={AccountBadge.MULTI}
+                        canCopy
                       />
                     </li>
                   ))}

--- a/packages/ui/src/pages/Settings/WatchedAccounts.tsx
+++ b/packages/ui/src/pages/Settings/WatchedAccounts.tsx
@@ -35,6 +35,7 @@ const WatchedAccounts = () => {
                     <AccountDisplayStyled
                       address={address}
                       canEdit
+                      canCopy
                     />
                     <IconButtonDeleteStyled
                       aria-label="delete"

--- a/packages/ui/src/utils/copyToClipboard.ts
+++ b/packages/ui/src/utils/copyToClipboard.ts
@@ -1,0 +1,7 @@
+export const copyTextToClipboard = async (text: string) => {
+  if ('clipboard' in navigator) {
+    return await navigator.clipboard.writeText(text)
+  } else {
+    return document.execCommand('copy', true, text)
+  }
+}


### PR DESCRIPTION
closes https://github.com/ChainSafe/Multix/issues/489

I went for the hover + copy tooltip
- so as to avoid having yet another icon (on top of the edit one)
- because our primary target is desktop and this is better than nothing, also mobile users may also figure it out (the tooltip will help)

The edge-cases here are in the dropdown menus where this function shouldn't be enabled.
I'd appreciate a check in browser I don't have access to such as Safari @asnaith and on mobile :pray

https://github.com/ChainSafe/Multix/assets/33178835/e209f8c4-8b92-46be-b69d-95d091ce744d


---

Submission checklist:

#### Layout

- [x] Change inspected in the desktop web ui
- [x] Change inspected in the mobile web ui

#### Compatibility

- [x] Functionality of change validated with a connected account with multisig
- [x] Applicable elements hidden / disabled for watched multisigs / pure
- [x] Looks good for solo multisig
- [x] Looks good for multisig with proxy
