### PR TITLE
fix: hydra walletconnect

### DIFF
--- a/packages/ui/src/components/WalletConnect/WalletConnectActiveSessions.tsx
+++ b/packages/ui/src/components/WalletConnect/WalletConnectActiveSessions.tsx
@@ -41,9 +41,27 @@ export const WalletConnectActiveSessions = () => {
           <ContentBoxStyled>
             <div className="info">
               <ul>
-                <li>Namespace: {session.requiredNamespaces?.polkadot?.chains?.join(', ')}</li>
-                <li>Methods: {session.requiredNamespaces?.polkadot?.methods?.join(', ')}</li>
-                <li>Events: {session.requiredNamespaces?.polkadot?.events?.join(', ')}</li>
+                <li>
+                  Namespace:{' '}
+                  {(
+                    session.requiredNamespaces?.polkadot?.chains ||
+                    session.optionalNamespaces?.polkadot?.chains
+                  )?.join(', ')}
+                </li>
+                <li>
+                  Methods:{' '}
+                  {(
+                    session.requiredNamespaces?.polkadot?.methods ||
+                    session.optionalNamespaces?.polkadot?.methods
+                  )?.join(', ')}
+                </li>
+                <li>
+                  Events:{' '}
+                  {(
+                    session.requiredNamespaces?.polkadot?.events ||
+                    session.optionalNamespaces?.polkadot?.events
+                  )?.join(', ')}
+                </li>
                 <li>Expiring: {expiryDate.toDateString()}</li>
               </ul>
             </div>

--- a/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
+++ b/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
@@ -31,25 +31,30 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
   }, [getAccountsWithNamespace, selectedMultiProxy?.multisigs, selectedMultiProxy?.proxy])
 
   const { methods, events, chains } = useMemo(
-    () =>
-      sessionProposal?.params.requiredNamespaces?.polkadot ||
-      sessionProposal?.params.optionalNamespaces?.polkadot || {
-        methods: [],
-        events: [],
-        chains: []
-      },
+    () => ({
+      methods: [
+        ...(sessionProposal?.params.requiredNamespaces?.polkadot?.methods ?? []),
+        ...(sessionProposal?.params.optionalNamespaces?.polkadot?.methods ?? [])
+      ],
+      events: [
+        ...(sessionProposal?.params.requiredNamespaces?.polkadot?.events ?? []),
+        ...(sessionProposal?.params.optionalNamespaces?.polkadot?.events ?? [])
+      ],
+      chains: [
+        ...(sessionProposal?.params.requiredNamespaces?.polkadot?.chains ?? []),
+        ...(sessionProposal?.params.optionalNamespaces?.polkadot?.chains ?? [])
+      ]
+    }),
     [sessionProposal?.params]
   )
 
   useEffect(() => {
     if (!web3wallet || !sessionProposal) return
 
-    const wCRequestedNetwork = chains?.[0]
-
-    if (wCRequestedNetwork !== currentNamespace) {
+    if (!chains.includes(currentNamespace)) {
       setErrorMessage(
         `Multix is not connected to the same network as the WalletConnect request. Please switch to the correct network.
-        - Requested: ${wCRequestedNetwork}
+        - Requested: ${chains}
         - Current: ${currentNamespace}`
       )
     }

--- a/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
+++ b/packages/ui/src/components/modals/WalletConnectSessionProposal.tsx
@@ -32,12 +32,13 @@ const WalletConnectSessionProposal = ({ onClose, className, sessionProposal }: P
 
   const { methods, events, chains } = useMemo(
     () =>
-      sessionProposal?.params.requiredNamespaces?.polkadot || {
+      sessionProposal?.params.requiredNamespaces?.polkadot ||
+      sessionProposal?.params.optionalNamespaces?.polkadot || {
         methods: [],
         events: [],
         chains: []
       },
-    [sessionProposal?.params.requiredNamespaces?.polkadot]
+    [sessionProposal?.params]
   )
 
   useEffect(() => {


### PR DESCRIPTION
closes https://github.com/ChainSafe/Multix/issues/541

Hydration wan't passing any required namespace any more and has everything in optional namespaces..
The WalletConnect doc says all fields are optional, so we just check that our current connected network is part of the list, and we go on with that.


In the mean time, we'll support both, and won't error out if only the optional is passed.