### PR TITLE
Support calls with no params

### DIFF
--- a/packages/ui/src/components/CallInfo.tsx
+++ b/packages/ui/src/components/CallInfo.tsx
@@ -252,7 +252,7 @@ const CallInfo = ({
     () => aggregatedData.callData && getDecodeUrl(aggregatedData.callData),
     [aggregatedData, getDecodeUrl]
   )
-  const hasArgs = useMemo(() => decodedCall && Object.keys(decodedCall).length > 0, [decodedCall])
+  const hasArgs = useMemo(() => decodedCall && decodedCall?.value.value, [decodedCall])
 
   return (
     <div

--- a/packages/ui/src/components/CallInfo.tsx
+++ b/packages/ui/src/components/CallInfo.tsx
@@ -252,7 +252,7 @@ const CallInfo = ({
     () => aggregatedData.callData && getDecodeUrl(aggregatedData.callData),
     [aggregatedData, getDecodeUrl]
   )
-  const hasArgs = useMemo(() => decodedCall && decodedCall?.value.value, [decodedCall])
+  const hasArgs = useMemo(() => decodedCall && decodedCall?.value?.value, [decodedCall])
 
   return (
     <div

--- a/packages/ui/src/utils/jsonPrint.ts
+++ b/packages/ui/src/utils/jsonPrint.ts
@@ -1,14 +1,20 @@
 import { Binary } from 'polkadot-api'
 import json5 from 'json5'
 
-export const JSONprint = (e: unknown) =>
-  json5
-    .stringify(e, {
-      replacer: (_, v) =>
-        typeof v === 'bigint' ? v.toString() : v instanceof Binary ? v.asText() : v,
-      space: 4
-    })
-    // remove { and }
-    .slice(1, -1)
-    // remove trailing comma if any
-    .replace(/,\s*$/, '')
+export const JSONprint = (e: unknown) => {
+  if (e === null || e === undefined) {
+    return ''
+  }
+  return (
+    json5
+      .stringify(e, {
+        replacer: (_, v) =>
+          typeof v === 'bigint' ? v.toString() : v instanceof Binary ? v.asText() : v,
+        space: 4
+      })
+      // remove { and }
+      .slice(1, -1)
+      // remove trailing comma if any
+      .replace(/,\s*$/, '')
+  )
+}


### PR DESCRIPTION
Close an issue happening with calls with no params. E.g `staking.chill`

![image](https://github.com/user-attachments/assets/21f7c1a0-e829-4c46-9771-11657ebd7cde)
